### PR TITLE
feat: 404 페이지와 404 response 처리 구현

### DIFF
--- a/e2e/sospeso.spec.ts
+++ b/e2e/sospeso.spec.ts
@@ -1,7 +1,17 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from "@playwright/test";
 
-test('get started link', async ({ page }) => {
-    await page.goto('http://localhost:4321/');
+const HOST = "http://localhost:4321";
 
-    await expect(page.getByRole('heading', { name: '코칭 소스페소' })).toBeVisible();
+test("존재하지 않는 소스페소 링크로 가려 하면 404페이지가 나온다", async ({
+  page,
+}) => {
+  await page.goto(HOST + "/sospeso/3123131");
+
+  await expect(
+    page.getByRole("heading", { name: "404 찾을 수 없는 페이지" }),
+  ).toBeVisible();
+
+  await page.getByRole("link", { name: "홈으로 돌아가기" }).click();
+
+  await expect(page).toHaveURL(HOST + "/");
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,6 +13,7 @@ import { defineConfig, devices } from '@playwright/test';
  */
 export default defineConfig({
   testDir: './e2e',
+  testMatch: /.*\.spec\.ts/,
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,19 @@
+---
+import Layout from '@/layouts/Layout.astro';
+---
+
+<Layout title="">
+  <div class="hero bg-base-200 min-h-screen">
+    <div class="hero-content text-center">
+      <div class="max-w-lg flex flex-col gap-8">
+        <span class="text-8xl"> ☕ </span>
+        <h1 class="text-5xl font-bold">404 찾을 수 없는 페이지</h1>
+        <div>
+          <p>잘못된 곳으로 온 것 같아요.</p>
+          <p>홈으로 돌아가시려면 아래 링크를 클릭해주세요.</p>
+        </div>
+        <a href="/" class="btn btn-primary">홈으로 돌아가기</a>
+      </div>
+    </div>
+  </div>
+</Layout>

--- a/src/pages/sospeso/[sospesoId]/index.astro
+++ b/src/pages/sospeso/[sospesoId]/index.astro
@@ -1,19 +1,23 @@
 ---
-import { actions } from "astro:actions";
-import invariant from "@/invariant";
-import { SospesoDetail } from "@/components/SospesoDetail";
-import Layout from "@/layouts/Layout.astro";
+import { actions } from 'astro:actions';
+import invariant from '@/invariant.ts';
+import { SospesoDetail } from '@/components/SospesoDetail.tsx';
+import Layout from '@/layouts/Layout.astro';
+import { NOT_FOUND_404_RESPONSE } from '@/web.ts';
 
 const { sospesoId } = Astro.params;
 
-// TODO: 404 페이지 정채
-invariant(sospesoId, "404 NOT FOUND");
+invariant(sospesoId, '404 NOT FOUND');
 
 const { data } = await actions.retrieveSospesoDetail({ sospesoId });
+
+if (!data) {
+  return NOT_FOUND_404_RESPONSE;
+}
 ---
 
 <Layout title="소스페소 상세">
   <div>
-    {data && <SospesoDetail sospeso={data} />}
+    <SospesoDetail sospeso={data} />
   </div>
 </Layout>

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,0 +1,4 @@
+export const NOT_FOUND_404_RESPONSE = new Response(null, {
+  status: 404,
+  statusText: "Not found",
+});


### PR DESCRIPTION
- 커스텀 404 페이지를 만들었습니다.
  - https://docs.astro.build/en/basics/astro-pages/#custom-404-error-page
- 존재하지 않는 sospeso id를 반환하면 404페이지로 가게 해서 불필요한 조건부 렌더링 처리를 없앴습니다.
  - https://docs.astro.build/en/guides/server-side-rendering/#return-a-response-object
- 플레이라이트로 간단하게 404페이지로 이동하는 걸 확인하는 테스트를 만들었습니다. 