### PR TITLE
crypto.randomUUID -> nanoid(14) 로 전환

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "date-fns": "^4.1.0",
     "dotenv": "^16.4.5",
     "drizzle-orm": "^0.36.1",
+    "nanoid": "^5.0.8",
     "react": "^18.3.1",
     "react-compiler-runtime": "19.0.0-beta-6fc168f-20241025",
     "react-dom": "^18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       drizzle-orm:
         specifier: ^0.36.1
         version: 0.36.1(@libsql/client@0.14.0)(@types/react@18.3.12)(kysely@0.27.4)(react@18.3.1)
+      nanoid:
+        specifier: ^5.0.8
+        version: 5.0.8
       react:
         specifier: ^18.3.1
         version: 18.3.1

--- a/src/actions/index.test.ts
+++ b/src/actions/index.test.ts
@@ -13,6 +13,9 @@ import {
 import { TEST_USER, TEST_USER_ID } from "@/auth/fixtures.ts";
 import { buildTestActionServer } from "./createTestActionServer.ts";
 import { LOGGED_IN_CONTEXT } from "./fixtures.ts";
+import { generateNanoId } from "@/adapters/generateId.ts";
+
+const generateId = generateNanoId;
 
 function runSospesoActionsTest(
   name: string,
@@ -52,7 +55,7 @@ function runSospesoActionsTest(
 
       expect(before).toStrictEqual([]);
 
-      const TEST_APPLICATION_ID = crypto.randomUUID();
+      const TEST_APPLICATION_ID = generateId();
       const TEST_NOW = new Date();
       await actionServer.applySospeso({
         sospesoId: issuedSospeso.id,
@@ -96,7 +99,7 @@ function runSospesoActionsTest(
         sospesoId: approvedSospeso.id,
         consumerId: TEST_USER_ID, // TODO user.id
         coachId: TEST_USER_ID, // user.id
-        consumingId: crypto.randomUUID(),
+        consumingId: generateId(),
         consumedAt: new Date(),
         content: "너무 도움이 되었어요!",
         memo: "장소 시간 어쩌구 코칭 일지 링크 등등",

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -22,7 +22,7 @@ export function buildSospesoActions(sospesoRepo: SospesoRepositoryI) {
       },
     }),
     retrieveSospesoDetail: definePureAction({
-      input: z.object({ sospesoId: z.string().uuid() }),
+      input: z.object({ sospesoId: z.string() }),
       handler: async (input) => {
         return sospesoRepo.retrieveSospesoDetail(input.sospesoId);
       },

--- a/src/adapters/IdGeneratorApi.ts
+++ b/src/adapters/IdGeneratorApi.ts
@@ -1,9 +1,0 @@
-export type IdGeneratorApi = {
-  generateId: () => string;
-};
-
-export const UUIDGeneratorApi = {
-  generateId: () => {
-    return crypto.randomUUID();
-  },
-};

--- a/src/adapters/generateId.ts
+++ b/src/adapters/generateId.ts
@@ -1,0 +1,6 @@
+import { nanoid } from "nanoid";
+
+export type generateIdI = () => string;
+
+const NANO_ID_LENGTH = 14;
+export const generateNanoId = () => nanoid(NANO_ID_LENGTH);

--- a/src/auth/fixtures.ts
+++ b/src/auth/fixtures.ts
@@ -1,10 +1,11 @@
-export const TEST_USER_ID = "PLKKa6BZL2d0uPf8Cm0z_";
+import { generateNanoId } from "@/adapters/generateId";
 
+export const TEST_USER_ID = generateNanoId();
 export const TEST_USER = {
   id: TEST_USER_ID,
   name: "김래빗",
   nickname: "김토끼",
-  email: "test@test.com",
+  email: TEST_USER_ID + "@test.kr",
   emailVerified: true,
   image: "",
   createdAt: new Date(),

--- a/src/components/SospesoConsumingForm.test.tsx
+++ b/src/components/SospesoConsumingForm.test.tsx
@@ -7,9 +7,9 @@ import {
   SospesoConsumingForm,
 } from "./SospesoConsumingForm.tsx";
 import { SafeEventHandler } from "@/event/SafeEventHandler.tsx";
-import { UUIDGeneratorApi } from "@/adapters/IdGeneratorApi.ts";
+import { generateNanoId } from "@/adapters/generateId.ts";
 
-const TEST_ID = UUIDGeneratorApi.generateId();
+const TEST_ID = generateNanoId();
 
 describe("SospesoConsumingForm", () => {
   test("필수 값을 입력하지 않으면 에러가 난다", async () => {
@@ -47,17 +47,11 @@ describe("SospesoConsumingForm", () => {
           result = command;
         }}
       >
-        <SospesoConsumingForm
-          idGeneratorApi={{
-            generateId() {
-              return TEST_ID;
-            },
-          }}
-        />
+        <SospesoConsumingForm generateId={() => TEST_ID} />
       </SafeEventHandler>,
     );
     const expected = {
-      coachId: UUIDGeneratorApi.generateId(),
+      coachId: generateNanoId(),
       consumingId: TEST_ID,
       consumedAt: new Date("2024-11-07T13:07:34.000Z"),
       content: "너무 도움이 되었어요!",

--- a/src/components/SospesoConsumingForm.tsx
+++ b/src/components/SospesoConsumingForm.tsx
@@ -1,7 +1,4 @@
-import {
-  UUIDGeneratorApi,
-  type IdGeneratorApi,
-} from "@/adapters/IdGeneratorApi";
+import { generateNanoId, type generateIdI } from "@/adapters/generateId";
 import { createSafeEvent } from "@/event/SafeEventBus";
 import { Form } from "@/shared/form/Form.tsx";
 import { Textarea } from "@/shared/form/Textarea.tsx";
@@ -26,11 +23,11 @@ export const sospesoConsumingEventBus = createSafeEvent(
 );
 
 export function SospesoConsumingForm({
-  idGeneratorApi = UUIDGeneratorApi,
+  generateId = generateNanoId,
 }: {
-  idGeneratorApi?: IdGeneratorApi;
+  generateId?: generateIdI;
 }) {
-  const consumingId = useMemo(() => idGeneratorApi.generateId(), []);
+  const consumingId = useMemo(() => generateId(), []);
 
   return (
     <Form

--- a/src/components/SospesoDetail.test.tsx
+++ b/src/components/SospesoDetail.test.tsx
@@ -62,9 +62,7 @@ describe("SospesoDetail", () => {
     await queryTL.button("공유 링크 복사하기").click();
 
     // then 클립보드에 링크가 복사된다
-    expect(result).toBe(
-      "http://localhost:63315/sospeso/2a88cac2-c021-48c6-9288-ecf0464d5bc2",
-    );
+    expect(result).toBe("http://localhost:63315/sospeso/" + ISSUED_SOSPESO.id);
   });
 
   test("소스페소를 사용한 후기를 볼 수 있다.", async () => {

--- a/src/components/SospesoIssuingForm.test.tsx
+++ b/src/components/SospesoIssuingForm.test.tsx
@@ -7,8 +7,9 @@ import {
   SospesoIssuingForm,
 } from "./SospesoIssuingForm";
 import { SafeEventHandler } from "@/event/SafeEventHandler";
+import { generateNanoId } from "@/adapters/generateId";
 
-const TEST_ID = crypto.randomUUID();
+const TEST_ID = generateNanoId();
 
 describe("SospesoIssuingForm", () => {
   test("필수 값을 입력하지 않으면 에러가 난다", async () => {
@@ -55,11 +56,7 @@ describe("SospesoIssuingForm", () => {
         }}
       >
         <SospesoIssuingForm
-          idGeneratorApi={{
-            generateId() {
-              return TEST_ID;
-            },
-          }}
+          generateId={() => TEST_ID}
           userNickname={expected.from}
         />
       </SafeEventHandler>,

--- a/src/components/SospesoIssuingForm.tsx
+++ b/src/components/SospesoIssuingForm.tsx
@@ -1,7 +1,4 @@
-import {
-  UUIDGeneratorApi,
-  type IdGeneratorApi,
-} from "@/adapters/IdGeneratorApi";
+import { generateNanoId, type generateIdI } from "@/adapters/generateId";
 import { createSafeEvent } from "@/event/SafeEventBus";
 import { Form } from "@/shared/form/Form";
 import { TextField } from "@/shared/form/TextField";
@@ -20,13 +17,13 @@ export const sospesoIssuingEventBus = createSafeEvent(
 );
 
 export function SospesoIssuingForm({
-  idGeneratorApi = UUIDGeneratorApi,
+  generateId = generateNanoId,
   userNickname,
 }: {
-  idGeneratorApi?: IdGeneratorApi;
+  generateId?: generateIdI;
   userNickname: string;
 }) {
-  const id = useMemo(() => idGeneratorApi.generateId(), [idGeneratorApi]);
+  const id = useMemo(() => generateId(), [generateId]);
 
   return (
     <Form

--- a/src/routing/href.test.ts
+++ b/src/routing/href.test.ts
@@ -1,7 +1,7 @@
+import { TEST_SOSPESO_ID } from "@/sospeso/fixtures.ts";
 import { href } from "./href.ts";
 import { describe, expect, test } from "vitest";
 
-const TEST_SOSPESO_ID = "08c08822-aa80-4ea3-8959-bed518802920";
 describe("href", () => {
   test("정적인 루트의 path를 생성할 수 있다", () => {
     expect(href("소스페소-발행", undefined)).toBe("/sospeso/issuing");
@@ -18,11 +18,11 @@ describe("href", () => {
 
   test("파라미터가 잘못되면 에러를 던진다", () => {
     expect(() =>
-      href("소스페소-상세", { sospesoId: "1123241243123" }),
+      href("소스페소-상세", { sospesoId: "한글id에 공백까지 들어가?" }),
     ).toThrowError("[invalid route params]");
   });
 
-  const TEST_CONSUMER_ID = "08c08822-aa80-4ea3-8959-bed518802920";
+  const TEST_CONSUMER_ID = "uugVC5lsmlBOHu";
   test("path에 없는 파라미터는 query string으로 붙는다", () => {
     expect(href("홈", { page: 1 })).toBe("/?page=1");
 
@@ -32,7 +32,7 @@ describe("href", () => {
         consumerId: TEST_CONSUMER_ID,
       }),
     ).toBe(
-      "/admin/sospeso/08c08822-aa80-4ea3-8959-bed518802920/consuming?consumerId=08c08822-aa80-4ea3-8959-bed518802920",
+      `/admin/sospeso/${TEST_SOSPESO_ID}/consuming?consumerId=${TEST_CONSUMER_ID}`,
     );
   });
 });

--- a/src/routing/parseRouteParams.test.ts
+++ b/src/routing/parseRouteParams.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, test } from "vitest";
 import { href } from "./href.ts";
-import { UUIDGeneratorApi } from "@/adapters/IdGeneratorApi.ts";
 import { parseRouteParamsFromUrl } from "./parseRouteParams.ts";
+import { generateNanoId } from "@/adapters/generateId.ts";
 
-const TEST_SOSPESO_ID = "08c08822-aa80-4ea3-8959-bed518802920";
-const TEST_CONSUMER_ID = UUIDGeneratorApi.generateId();
+const TEST_SOSPESO_ID = generateNanoId();
+const TEST_CONSUMER_ID = generateNanoId();
 describe("parseRouteParams", () => {
   test("정적인 route의 params를 읽어올 수 있다", () => {
     const path = href("어드민", undefined);

--- a/src/routing/routes.ts
+++ b/src/routing/routes.ts
@@ -27,13 +27,13 @@ export const routes = {
   "소스페소-상세": {
     path: "/sospeso/[sospesoId]",
     paramsSchema: v.object({
-      sospesoId: v.pipe(v.string(), v.uuid()),
+      sospesoId: v.pipe(v.string(), v.nanoid()),
     }),
   },
   "소스페소-신청": {
     path: "/sospeso/[sospesoId]/application",
     paramsSchema: v.object({
-      sospesoId: v.pipe(v.string(), v.uuid()),
+      sospesoId: v.string(),
     }),
   },
   어드민: {
@@ -42,8 +42,8 @@ export const routes = {
   "어드민-소스페소-사용": {
     path: "/admin/sospeso/[sospesoId]/consuming",
     paramsSchema: v.object({
-      sospesoId: v.pipe(v.string(), v.uuid()),
-      consumerId: v.pipe(v.string(), v.uuid()),
+      sospesoId: v.string(),
+      consumerId: v.string(),
     }),
   },
   "가짜-이메일-인박스": {

--- a/src/shared/Pagination.tsx
+++ b/src/shared/Pagination.tsx
@@ -1,6 +1,7 @@
 import invariant from "@/invariant.ts";
 import { Link } from "@/routing/Link";
-import type { RouteKeys, RouteParams } from "@/routing/routes";
+import type { DynamicRoute, RouteKeys, routes } from "@/routing/routes";
+import type * as v from 'valibot';
 
 function range(start: number, end: number) {
   return Array.from({ length: end - 1 }).map((_, index) => index + start);
@@ -15,7 +16,9 @@ export function Pagination<RouteKey extends RouteKeys>({
   current: number;
   end: number;
   routeKey: RouteKey;
-  params: RouteParams<RouteKey>;
+  params: (typeof routes)[RouteKey] extends DynamicRoute
+  ? Omit<v.InferOutput<(typeof routes)[RouteKey]["paramsSchema"]>, "page">
+  : undefined;
 }) {
   invariant(current >= 1, "페이지는 양의 정수여야 합니다!");
   invariant(current <= end, "마지막 페이지를 넘어섰습니다!");

--- a/src/sospeso/domain.test.ts
+++ b/src/sospeso/domain.test.ts
@@ -12,8 +12,11 @@ import {
 } from "./domain.ts";
 import { SOSPESO_PRICE } from "./constants.ts";
 import { TEST_USER_ID } from "@/auth/fixtures.ts";
+import { generateNanoId } from "@/adapters/generateId.ts";
 
-const sospesoId = crypto.randomUUID();
+const generateId = generateNanoId;
+
+const sospesoId = generateId();
 const now = new Date();
 
 export const issuedSospeso = issueSospeso({
@@ -25,7 +28,7 @@ export const issuedSospeso = issueSospeso({
   issuerId: TEST_USER_ID,
 });
 
-const firstApplicationId = crypto.randomUUID();
+const firstApplicationId = generateId();
 
 export const appliedSospeso = applySospeso(issuedSospeso, {
   sospesoId: issuedSospeso.id,
@@ -62,7 +65,7 @@ describe("sospeso", () => {
     expect(() => {
       applySospeso(appliedSospeso, {
         sospesoId: issuedSospeso.id,
-        applicationId: crypto.randomUUID(),
+        applicationId: generateNanoId(),
         appliedAt: new Date(),
         applicantId: TEST_USER_ID,
         content: "",
@@ -101,7 +104,7 @@ describe("sospeso", () => {
   test("거절한 소스페소는 다시 신청할 수 있다", () => {
     expect(isApplicationLocked(rejectedSospeso)).toBe(false);
 
-    const secondApplicationId = crypto.randomUUID();
+    const secondApplicationId = generateId();
 
     const appliedSospeso = applySospeso(rejectedSospeso, {
       sospesoId: rejectedSospeso.id,
@@ -123,7 +126,7 @@ describe("sospeso", () => {
   });
 
   test("두 번 이상 거절할 수도 있다", () => {
-    const secondApplicationId = crypto.randomUUID();
+    const secondApplicationId = generateId();
 
     const appliedSospeso = applySospeso(rejectedSospeso, {
       sospesoId: rejectedSospeso.id,
@@ -146,7 +149,7 @@ describe("sospeso", () => {
 
   const consumedSospeso = consumeSospeso(approvedSospeso, {
     sospesoId: issuedSospeso.id,
-    consumingId: crypto.randomUUID(),
+    consumingId: generateNanoId(),
     consumedAt: new Date(),
     content: "너무 도움이 되었어요! 덕분에 취직도 잘할듯?",
     memo: "장소: 약수역, 시간: 2022년 12월 11일, 어찌저찌 큰 도움이 되셨다고.",

--- a/src/sospeso/fixtures.ts
+++ b/src/sospeso/fixtures.ts
@@ -1,9 +1,14 @@
+import { generateNanoId } from "@/adapters/generateId.ts";
 import type { SospesoApplicationStatus } from "./domain.ts";
+
+const generateId = generateNanoId;
+
+export const TEST_SOSPESO_ID = "DaLNnQs8nfVgs0";
 
 export const TEST_ISSUED_AT = new Date("2024-11-09T00:00:00Z");
 
 export const TEST_SOSPESO_LIST_ITEM = {
-  id: crypto.randomUUID(),
+  id: generateId(),
   from: "탐정토끼",
   to: "퀴어 문화 축제 올 사람",
   issuedAt: TEST_ISSUED_AT,
@@ -11,7 +16,7 @@ export const TEST_SOSPESO_LIST_ITEM = {
 } as const;
 
 export const ISSUED_SOSPESO = {
-  id: "2a88cac2-c021-48c6-9288-ecf0464d5bc2",
+  id: TEST_SOSPESO_ID,
   from: "탐정토끼",
   to: "퀴어 문화 축제 올 사람",
   status: "issued", // 읽기 모델 "issued" | "pending" | "consumed"
@@ -19,7 +24,7 @@ export const ISSUED_SOSPESO = {
 } as const;
 
 export const PENDING_SOSPESO = {
-  id: "2a88cac2-c021-48c6-9288-ecf0464d5bc2",
+  id: TEST_SOSPESO_ID,
   from: "탐정토끼",
   to: "퀴어 문화 축제 올 사람",
   status: "pending", // 읽기 모델 "issued" | "pending" | "consumed"
@@ -27,7 +32,7 @@ export const PENDING_SOSPESO = {
 } as const;
 
 export const CONSUMED_SOSPESO = {
-  id: "2a88cac2-c021-48c6-9288-ecf0464d5bc2",
+  id: TEST_SOSPESO_ID,
   from: "탐정토끼",
   to: "퀴어 문화 축제 올 사람",
   status: "consumed", // 읽기 모델 "issued" | "pending" | "consumed"
@@ -43,13 +48,13 @@ export const CONSUMED_SOSPESO = {
 const TEST_NOW = new Date("2024-11-06T00:00:00Z");
 
 export const TEST_APPLIED_APPLICATION = {
-  id: crypto.randomUUID(),
-  sospesoId: crypto.randomUUID(),
+  id: generateId(),
+  sospesoId: generateId(),
   to: "퀴어 문화 축제 올 사람",
   status: "applied",
   appliedAt: TEST_NOW,
   applicant: {
-    id: crypto.randomUUID(),
+    id: generateId(),
     nickname: "김토끼",
   },
   content:
@@ -57,13 +62,13 @@ export const TEST_APPLIED_APPLICATION = {
 } as const;
 
 export const TEST_APPROVED_APPLICATION = {
-  id: crypto.randomUUID(),
-  sospesoId: crypto.randomUUID(),
+  id: generateId(),
+  sospesoId: generateId(),
   to: "시각 장애가 있는 분",
   status: "approved",
   appliedAt: new Date(TEST_NOW.valueOf() - 1000 * 60 * 60 * 24),
   applicant: {
-    id: crypto.randomUUID(),
+    id: generateId(),
     nickname: "해적 토끼",
   },
   content: "제 왼쪽 눈을 보십시오. 이것이야 말로 증거가 아니겠습니까?ㄷ",
@@ -83,13 +88,13 @@ export const TEST_APPLICATION_LIST: {
 }[] = [
   TEST_APPLIED_APPLICATION,
   {
-    id: crypto.randomUUID(),
-    sospesoId: crypto.randomUUID(),
+    id: generateId(),
+    sospesoId: generateId(),
     to: "퀴어 문화 축제 올 사람",
     status: "rejected",
     appliedAt: new Date(TEST_NOW.valueOf() - 1000 * 60 * 60 * 24),
     applicant: {
-      id: crypto.randomUUID(),
+      id: generateId(),
       nickname: "혐오자",
     },
     content: "저는 소스페소에 이상한 요청을 보낸 나쁜 사람입니다",


### PR DESCRIPTION
#34 에서 고민을 하고 이런저런 글을 찾아봤는데 nanoid를 쓰면 괜찮아 보여서 바꿔두었습니다. 가장 큰 이유는 UUID처럼 너무 길어서 URL이 못 생기지 않았고요,  클라이언트에서 생성할 수 있어 test가 쉽다는 점입니다. (db에 의존하는 auto increment는 test하기가 까다롭죠)

이제 모두 인터페이스로 감싸두었기 때문에, 실제 프로덕션 DB가 올라가기 전까지는 generateId 구현체 1줄만 바꾸면 모두 적용할 수 있고 테스트도 해봤습니다.