### PR TITLE
소스페소 상세보기 - 대기중 버튼에 마우스 올리면 툴팁 표시

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,6 +17,7 @@
     "Supabase",
     "tailwindcss",
     "tanstack",
+    "Toastify",
     "TURSO",
     "undefinedable",
     "valibot",

--- a/src/components/SospesoDetail.test.tsx
+++ b/src/components/SospesoDetail.test.tsx
@@ -43,7 +43,7 @@ describe("SospesoDetail", () => {
   test("대기 중인 소스페소는 대기중 버튼이 비활성화되어있다.", async () => {
     render(<SospesoDetail sospeso={PENDING_SOSPESO} />);
 
-    await expectTL(queryTL.button("대기중")).toHaveAttribute("disabled", "");
+    await expectTL(queryTL.button("대기중")).toBeDisabled();
   });
 
   test("대기중 버튼에 마우스를 올리면 도움말 툴팁을 보여준다.", async () => {
@@ -51,7 +51,10 @@ describe("SospesoDetail", () => {
 
     await queryTL.button("대기중").hover();
 
-    await expectTL(queryTL.tooltip("대기중")).toBeVisible();
+    const tooltip = queryTL.tooltip(
+      "이미 신청한 사람이 있어 코칭을 기다리고 있습니다",
+    );
+    await expectTL(tooltip).toBeVisible();
   });
 
   test("소스페소 링크를 복사하면 성공했다는 토스트 메세지를 보여준다.", async () => {

--- a/src/components/SospesoDetail.test.tsx
+++ b/src/components/SospesoDetail.test.tsx
@@ -10,7 +10,6 @@ import {
   PENDING_SOSPESO,
 } from "@/sospeso/fixtures";
 import { ToastifyToastContainer, toastifyToastApi } from "@/adapters/toastApi";
-import userEvent from "@testing-library/user-event";
 
 const STAMP_ALT = "사용됨";
 
@@ -50,7 +49,7 @@ describe("SospesoDetail", () => {
   test("대기중 버튼에 마우스를 올리면 도움말 툴팁을 보여준다.", async () => {
     render(<SospesoDetail sospeso={PENDING_SOSPESO} />);
 
-    userEvent.hover(queryTL.button("대기중").get());
+    await queryTL.button("대기중").hover();
 
     await expectTL(queryTL.tooltip("대기중")).toBeVisible();
   });

--- a/src/components/SospesoDetail.test.tsx
+++ b/src/components/SospesoDetail.test.tsx
@@ -10,6 +10,7 @@ import {
   PENDING_SOSPESO,
 } from "@/sospeso/fixtures";
 import { ToastifyToastContainer, toastifyToastApi } from "@/adapters/toastApi";
+import userEvent from "@testing-library/user-event";
 
 const STAMP_ALT = "사용됨";
 
@@ -44,6 +45,14 @@ describe("SospesoDetail", () => {
     render(<SospesoDetail sospeso={PENDING_SOSPESO} />);
 
     await expectTL(queryTL.button("대기중")).toHaveAttribute("disabled", "");
+  });
+
+  test("대기중 버튼에 마우스를 올리면 도움말 툴팁을 보여준다.", async () => {
+    render(<SospesoDetail sospeso={PENDING_SOSPESO} />);
+
+    userEvent.hover(queryTL.button("대기중").get());
+
+    await expectTL(queryTL.tooltip("대기중")).toBeVisible();
   });
 
   test("소스페소 링크를 복사하면 성공했다는 토스트 메세지를 보여준다.", async () => {

--- a/src/components/SospesoDetail.tsx
+++ b/src/components/SospesoDetail.tsx
@@ -1,4 +1,10 @@
 import {
+  Tooltip,
+  TooltipAnchor,
+  TooltipProvider,
+} from "@ariakit/react/tooltip";
+
+import {
   browserClipboardApi,
   type ClipboardApiI,
 } from "@/adapters/clipboardApi";
@@ -46,47 +52,53 @@ export function SospesoDetail({
         </Link>
       )}
 
-      {sospeso.status === "pending" && (
-        <div
-          role="tooltip"
-          id="pendingSospeso"
-          data-tip="승인을 기다리고 있는 소스페소입니다."
-          className="tooltip"
+      <div>
+        {sospeso.status === "pending" && (
+          <TooltipProvider timeout={100}>
+            <TooltipAnchor
+              render={
+                <button
+                  aria-describedby="pendingSospeso"
+                  className="btn aria-disabled:btn-gray cursor-wait"
+                  aria-disabled="true"
+                >
+                  <span className="loading loading-spinner"></span>
+                  대기중
+                </button>
+              }
+            />
+            <Tooltip className="tooltip tooltip-content">
+              이미 신청한 사람이 있어 코칭을 기다리고 있습니다
+            </Tooltip>
+          </TooltipProvider>
+        )}
+
+        {sospeso.status === "consumed" && <img alt="사용됨" />}
+
+        {sospeso.status === "consumed" && (
+          <div>
+            <span>{sospeso.consuming.consumer.nickname}</span>
+            <p>{sospeso.consuming.content}</p>
+          </div>
+        )}
+
+        <button
+          className="btn btn-primary"
+          onClick={async () => {
+            try {
+              await clipboardApi.copy(
+                window.origin +
+                  href("소스페소-상세", { sospesoId: sospeso.id }),
+              );
+              toastApi.toast("소스페소 링크를 복사했어요!", "success");
+            } catch {
+              toastApi.toast("복사 권한을 허용했는지 확인해 주세요.", "error");
+            }
+          }}
         >
-          <button
-            aria-describedby="pendingSospeso"
-            className="btn btn-primary !pointer-events-auto"
-            disabled
-          >
-            대기중
-          </button>
-        </div>
-      )}
-
-      {sospeso.status === "consumed" && <img alt="사용됨" />}
-
-      {sospeso.status === "consumed" && (
-        <div>
-          <span>{sospeso.consuming.consumer.nickname}</span>
-          <p>{sospeso.consuming.content}</p>
-        </div>
-      )}
-
-      <button
-        className="btn btn-primary"
-        onClick={async () => {
-          try {
-            await clipboardApi.copy(
-              window.origin + href("소스페소-상세", { sospesoId: sospeso.id }),
-            );
-            toastApi.toast("소스페소 링크를 복사했어요!", "success");
-          } catch {
-            toastApi.toast("복사 권한을 허용했는지 확인해 주세요.", "error");
-          }
-        }}
-      >
-        공유 링크 복사하기
-      </button>
+          공유 링크 복사하기
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/components/SospesoDetail.tsx
+++ b/src/components/SospesoDetail.tsx
@@ -47,9 +47,20 @@ export function SospesoDetail({
       )}
 
       {sospeso.status === "pending" && (
-        <button className="btn btn-primary" disabled>
-          대기중
-        </button>
+        <div
+          role="tooltip"
+          id="pendingSospeso"
+          data-tip="승인을 기다리고 있는 소스페소입니다."
+          className="tooltip"
+        >
+          <button
+            aria-describedby="pendingSospeso"
+            className="btn btn-primary !pointer-events-auto"
+            disabled
+          >
+            대기중
+          </button>
+        </div>
       )}
 
       {sospeso.status === "consumed" && <img alt="사용됨" />}

--- a/src/index.css
+++ b/src/index.css
@@ -65,4 +65,16 @@ body {
     background-color: oklch(var(--p, var(--b2)) / var(--tw-bg-opacity));
     color: white;
   }
+
+  .tooltip-content {
+    max-width: 20rem;
+    white-space: normal;
+    border-radius: 0.25rem;
+    padding: 0.25rem 0.5rem;
+    font-size: 0.875rem;
+    line-height: 1.25rem;
+    background-color: var(--tooltip-color);
+    color: var(--tooltip-text-color);
+    width: max-content;
+  }
 }

--- a/src/siheom/queryTL.ts
+++ b/src/siheom/queryTL.ts
@@ -39,6 +39,7 @@ export type TLocator = {
     options?: Parameters<typeof userEvent.type>[2],
   ): Promise<void>;
   clear(): Promise<void>;
+  hover(): Promise<void>;
   waitFor(): Promise<void>;
   find(): Promise<HTMLElement>;
   findAll(): Promise<HTMLElement[]>;
@@ -191,6 +192,16 @@ export function createQueryTL(getBaseElement = () => document.body) {
               return swapStackAsync(fakeError, error);
             }
           },
+          async hover() {
+            const fakeError = new Error();
+            try {
+              await base()
+                .findByRole(role, { name })
+                .then(($el) => userEvent.hover($el));
+            } catch (error) {
+              return swapStackAsync(fakeError, error);
+            }
+          },
           async waitFor() {
             const fakeError = new Error();
             try {
@@ -262,6 +273,9 @@ export function createQueryTL(getBaseElement = () => document.body) {
         },
         async clear() {
           return find().then(($el) => userEvent.clear($el));
+        },
+        async hover() {
+          return find().then(($el) => userEvent.hover($el));
         },
         async waitFor() {
           return find().then(() => undefined);


### PR DESCRIPTION
기능 추가

- pending 상태인 소스페소의 상세보기에서 대기중 버튼에 마우스를 올리면 툴팁을 보여줍니다.

기타

- 탐토님이 공유해주셨던 [MDN 문서](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tooltip_role)에서 몰랐던 사실을 배울 수 있어서 좋았습니다. 문서에는 1) esc 입력에 따라 툴팁이 사라져야 하고, 2) 툴팁에 마우스를 옮길 때에도 요소가 유지되어야 한다고 설명되어 있지만 구현하지 않았어요. 이런 요구사항도 이 작업에 포함시켜야 할까요?
- 현재 버튼 위치상 뷰포트 바깥으로 툴팁이 묻히는 현상이 있지만 추후 디자인 반영을 고려하여 그대로 두었어요.