### PR TITLE
feat: payple test 결제

### DIFF
--- a/src/actions/index.test.ts
+++ b/src/actions/index.test.ts
@@ -34,18 +34,29 @@ function runSospesoActionsTest(
   }
 
   describe("sospesoActionServer: " + name, () => {
-    test("issueSospeso", async () => {
+    test("createIssuingSospesoPayment", async () => {
       const actionServer = await createTestActionServer({});
-      const before = await actionServer.retrieveSospesoList({});
 
-      expect(before).toHaveLength(0);
+      await expect(() =>
+        actionServer.generatePaymentLink({
+          paymentId: TEST_SOSPESO_LIST_ITEM.id,
+        }),
+      ).rejects.toThrowError("결제가 존재하지 않습니다! : 7pD2z_SkcIWR75");
 
-      await actionServer.issueSospeso(
+      await actionServer.createIssuingSospesoPayment(
         {
           sospesoId: TEST_SOSPESO_LIST_ITEM.id,
           ...TEST_SOSPESO_LIST_ITEM,
         },
         LOGGED_IN_CONTEXT,
+      );
+
+      const { paymentLink } = await actionServer.generatePaymentLink({
+        paymentId: TEST_SOSPESO_LIST_ITEM.id,
+      });
+
+      expect(paymentLink).toBe(
+        "https://democpay.payple.kr/php/link/?SID=MTI6MTU4NDYwNzI4Mg?id=7pD2z_SkcIWR75",
       );
     });
 

--- a/src/adapters/authApi.ts
+++ b/src/adapters/authApi.ts
@@ -50,15 +50,15 @@ export const authApi: AuthApi = {
         nickname,
       });
 
-      if (error?.message === 'User with this email already exists') {
-        return 'already-exists'
+      if (error?.message === "User with this email already exists") {
+        return "already-exists";
       }
-      if (error){
+      if (error) {
         console.error(error);
-        return "unknown-error"
+        return "unknown-error";
       }
 
-      return "success"
+      return "success";
     },
   },
   login: {

--- a/src/components/auth/ChangePasswordForm.test.tsx
+++ b/src/components/auth/ChangePasswordForm.test.tsx
@@ -2,7 +2,10 @@ import { render } from "@testing-library/react";
 import { describe, expect, test } from "vitest";
 import { queryTL } from "@/siheom/queryTL.ts";
 import { expectTL } from "@/siheom/expectTL.ts";
-import { changePasswordBus, ChangePasswordForm } from "./ChangePasswordForm.tsx";
+import {
+  changePasswordBus,
+  ChangePasswordForm,
+} from "./ChangePasswordForm.tsx";
 import { SafeEventHandler } from "@/event/SafeEventHandler.tsx";
 
 const TEST_EMAIL = "taehee.kim@life-lifter.com";
@@ -26,7 +29,7 @@ describe("ChangePasswordForm", () => {
     await expectTL(queryTL.textbox("이메일")).toHaveErrorMessage(
       "이메일이 없어요",
     );
-    
+
     expect(result).toEqual({});
   });
 
@@ -47,7 +50,7 @@ describe("ChangePasswordForm", () => {
     await queryTL.button("비밀번호 변경 이메일 보내기").click();
 
     expect(result).toEqual({
-      email: TEST_EMAIL
+      email: TEST_EMAIL,
     });
   });
 });

--- a/src/components/auth/LoginForm.test.tsx
+++ b/src/components/auth/LoginForm.test.tsx
@@ -6,7 +6,7 @@ import { magicLinkLoginBus, LoginForm } from "./LoginForm.tsx";
 import { SafeEventHandler } from "@/event/SafeEventHandler.tsx";
 
 const TEST_EMAIL = "taehee.kim@life-lifter.com";
-const TEST_PASSWORD = "!1q2w3e4r!"
+const TEST_PASSWORD = "!1q2w3e4r!";
 
 describe("LoginForm", () => {
   test("이메일을 입력하지 않으면 로그인할 수 없다", async () => {
@@ -27,7 +27,7 @@ describe("LoginForm", () => {
     await expectTL(queryTL.textbox("이메일")).toHaveErrorMessage(
       "이메일이 없어요",
     );
-    
+
     await expectTL(queryTL.textbox("비밀번호")).toHaveErrorMessage(
       "최소 10자리 이상이어야해요",
     );
@@ -54,7 +54,7 @@ describe("LoginForm", () => {
 
     expect(result).toEqual({
       email: TEST_EMAIL,
-      "password": TEST_PASSWORD,
+      password: TEST_PASSWORD,
     });
   });
 });

--- a/src/components/auth/ResetPasswordForm.test.tsx
+++ b/src/components/auth/ResetPasswordForm.test.tsx
@@ -5,7 +5,7 @@ import { expectTL } from "@/siheom/expectTL.ts";
 import { resetPasswordBus, ResetPasswordForm } from "./ResetPasswordForm.tsx";
 import { SafeEventHandler } from "@/event/SafeEventHandler.tsx";
 
-const TEST_PASSWORD = "!1q2w3e4r!"
+const TEST_PASSWORD = "!1q2w3e4r!";
 
 describe("ResetPasswordForm", () => {
   test("이메일을 입력하지 않으면 로그인할 수 없다", async () => {
@@ -22,7 +22,7 @@ describe("ResetPasswordForm", () => {
     );
 
     await queryTL.button("비밀번호 변경하기").click();
-    
+
     await expectTL(queryTL.textbox("새 비밀번호")).toHaveErrorMessage(
       "최소 10자리 이상이어야해요",
     );
@@ -47,7 +47,7 @@ describe("ResetPasswordForm", () => {
     await queryTL.button("비밀번호 변경하기").click();
 
     expect(result).toEqual({
-      "password": TEST_PASSWORD,
+      password: TEST_PASSWORD,
     });
   });
 });

--- a/src/components/auth/SignUpForm.tsx
+++ b/src/components/auth/SignUpForm.tsx
@@ -67,15 +67,19 @@ export function SignUpForm() {
             autoComplete="new-password"
             minLength={10}
           />
-          <TextField label="이름(실명)" name="name" autoComplete="name" 
-            placeholder='홍길동'/>
+          <TextField
+            label="이름(실명)"
+            name="name"
+            autoComplete="name"
+            placeholder="홍길동"
+          />
           <TextField
             label="전화번호"
             name="phone"
-            placeholder='010-1234-5678'
+            placeholder="010-1234-5678"
             autoComplete="tel-national"
           />
-          <TextField label="별명" name="nickname" placeholder='다정한 토끼'/>
+          <TextField label="별명" name="nickname" placeholder="다정한 토끼" />
 
           <button className="btn btn-primary w-full" type="submit">
             회원가입하기

--- a/src/pages/auth/signup/index.astro
+++ b/src/pages/auth/signup/index.astro
@@ -16,29 +16,17 @@ import Layout from "@/layouts/Layout.astro";
   const toastApi = toastifyToastApi;
 
   signUpBus.on(window.document.body, (command) => {
-    authApi.signUp
-      .email(command)
-      .then((status) => {
-        if (status === "success"){
+    authApi.signUp.email(command).then((status) => {
+      if (status === "success") {
+        navigate("회원가입-이메일-전송-완료", { email: command.email });
+      }
 
-          navigate("회원가입-이메일-전송-완료", { email: command.email });
-
-        }
-        
-        if(status === "already-exists"){
-          
-        toastApi.toast(
-          "이미 가입한 이메일이에요",
-          "error",
-        );
-        }
-        if(status === "unknown-error"){
-          
-          toastApi.toast(
-            "알 수 없는 에러 잠시 뒤에 다시 시도해주세요.",
-            "error",
-          );
-          }
-      })
+      if (status === "already-exists") {
+        toastApi.toast("이미 가입한 이메일이에요", "error");
+      }
+      if (status === "unknown-error") {
+        toastApi.toast("알 수 없는 에러 잠시 뒤에 다시 시도해주세요.", "error");
+      }
+    });
   });
 </script>

--- a/src/pages/payment/[paymentId].astro
+++ b/src/pages/payment/[paymentId].astro
@@ -1,0 +1,35 @@
+---
+import Layout from "@/layouts/Layout.astro";
+import { parseRouteParamsFromUrl } from "@/routing/parseRouteParams";
+import { actions } from "astro:actions";
+
+const session = Astro.locals.session;
+
+if (!session) {
+  // TODO! 로그인 페이지로 리다이렉트 시키기
+  //  https://docs.astro.build/en/guides/routing/#dynamic-redirects
+  return Astro.redirect("/auth/login");
+}
+
+const { paymentId } = parseRouteParamsFromUrl(
+  "소스페소-결제",
+  new URL(Astro.url),
+);
+
+const { data, error } = await actions.generatePaymentLink({ paymentId });
+---
+
+<Layout title="소스페소 발행하기">
+  {error && <div>죄송합니다. 결제 링크 생성에 실패했어요 ㅠㅠ</div>}
+
+  {
+    data && (
+      <div>
+        <h2>결제를 진행해주세요.</h2>{" "}
+        <a class="btn btn-primary" href={data.paymentLink} target="_blank">
+          결제 진행하기
+        </a>
+      </div>
+    )
+  }
+</Layout>

--- a/src/pages/sospeso/issuing.astro
+++ b/src/pages/sospeso/issuing.astro
@@ -16,19 +16,23 @@ if (!session) {
 </Layout>
 
 <script>
+  import { toastifyToastApi } from "@/adapters/toastApi";
   import { sospesoIssuingEventBus } from "@/components/SospesoIssuingForm";
   import { navigate } from "@/routing/navigate";
   import { actions } from "astro:actions";
+  const toastApi = toastifyToastApi;
 
-  sospesoIssuingEventBus.on(window.document.body, (command) => {
+  sospesoIssuingEventBus.on(window.document.body, async (command) => {
     actions
-      .issueSospeso({ ...command, issuedAt: new Date() })
-      .then((result) => {
-        if (result.error) {
-          return console.error(result.error);
-        }
-
-        navigate("소스페소-상세", { sospesoId: command.sospesoId });
+      .createIssuingSospesoPayment(command)
+      .then(() => {
+        navigate("소스페소-결제", { paymentId: command.sospesoId });
+      })
+      .catch(() => {
+        toastApi.toast(
+          "알 수 없는 에러가 발생했어요. 잠시 뒤에 다시 시도해주세요.",
+          "error",
+        );
       });
   });
 </script>

--- a/src/payment/domain.test.ts
+++ b/src/payment/domain.test.ts
@@ -1,28 +1,39 @@
 import { describe, expect, test } from "vitest";
 import { completePayment, createSospesoIssuingPayment, isPaid } from "./domain";
 import { EXAMPLE_PAYMENT_PAYLOAD } from "./fixtures";
+import { TEST_SOSPESO_ID, TEST_SOSPESO_LIST_ITEM } from "@/sospeso/fixtures";
+import { TEST_USER_ID } from "@/auth/fixtures";
 
 const TEST_PAYMENT_ID = "eaT72utJOlX_16";
 const NOW = new Date("2024-11-14T00:00:00Z");
+
+const SOSPESO_ISSUING_COMMAND = {
+  sospesoId: TEST_SOSPESO_ID,
+  issuedAt: TEST_SOSPESO_LIST_ITEM.issuedAt,
+  from: TEST_SOSPESO_LIST_ITEM.from,
+  to: TEST_SOSPESO_LIST_ITEM.to,
+  issuerId: TEST_USER_ID,
+  paidAmount: 80000,
+};
 
 describe("payment", () => {
   test("새로운 소스페소 발행 결제를 생성할 수 있다", () => {
     const payment = createSospesoIssuingPayment({
       sospesoId: TEST_PAYMENT_ID,
       now: NOW,
+      totalAmount: 80000,
+      command: SOSPESO_ISSUING_COMMAND,
     });
 
     expect(payment).toStrictEqual({
-      afterLinkUrl: "http://localhost:3000/sospeso/eaT72utJOlX_16",
+      afterLinkUrl: "http://localhost:3000/sospeso/DaLNnQs8nfVgs0",
       expiredDate: new Date("2024-11-15T00:00:00Z"),
       goodsDescription:
         "1시간 반에서 2시간의 코칭을 수혜자에게 제공하는 소스페소를 구매합니다.",
       goodsTitle: "코칭 소스페소 1장",
       id: TEST_PAYMENT_ID,
-      params: {
-        sospesoId: TEST_PAYMENT_ID,
-      },
-      paymentTotalAmount: 0,
+      command: SOSPESO_ISSUING_COMMAND,
+      totalAmount: 80000,
       status: "initiated",
     });
   });
@@ -31,20 +42,20 @@ describe("payment", () => {
     const payment = createSospesoIssuingPayment({
       sospesoId: TEST_PAYMENT_ID,
       now: NOW,
+      totalAmount: 80000,
+      command: SOSPESO_ISSUING_COMMAND,
     });
 
     const result = completePayment(payment, EXAMPLE_PAYMENT_PAYLOAD);
     expect(result).toStrictEqual({
-      afterLinkUrl: "http://localhost:3000/sospeso/eaT72utJOlX_16",
+      afterLinkUrl: "http://localhost:3000/sospeso/DaLNnQs8nfVgs0",
       expiredDate: new Date("2024-11-15T00:00:00Z"),
       goodsDescription:
         "1시간 반에서 2시간의 코칭을 수혜자에게 제공하는 소스페소를 구매합니다.",
       goodsTitle: "코칭 소스페소 1장",
       id: TEST_PAYMENT_ID,
-      params: {
-        sospesoId: TEST_PAYMENT_ID,
-      },
-      paymentTotalAmount: 0,
+      command: SOSPESO_ISSUING_COMMAND,
+      totalAmount: 80000,
       status: "paid",
       paymentResult: EXAMPLE_PAYMENT_PAYLOAD,
     });

--- a/src/payment/domain.ts
+++ b/src/payment/domain.ts
@@ -1,5 +1,6 @@
 import { env } from "@/adapters/env";
 import { href } from "@/routing/href";
+import type { SospesoIssuingCommand } from "@/sospeso/domain";
 import { addHours } from "date-fns/addHours";
 
 export type PaidPaymentT = {
@@ -7,9 +8,9 @@ export type PaidPaymentT = {
   status: "paid";
   goodsTitle: string; // 상품 이름
   goodsDescription: string; // 상품 설명
-  paymentTotalAmount: number; // 상품의 가격
+  totalAmount: number; // 상품의 가격
   expiredDate: Date; // 링크 만료 일시
-  params: Record<string, string>; // 추가로 제공할 파라미터
+  command: any;
   afterLinkUrl: string; // 결제 완료 후 이동할 URL
   paymentResult: Record<string, string>; // 결제 결과 원본
 };
@@ -20,30 +21,35 @@ export type PaymentT =
       status: "initiated";
       goodsTitle: string; // 상품 이름
       goodsDescription: string; // 상품 설명
-      paymentTotalAmount: number; // 상품의 가격
+      totalAmount: number; // 상품의 가격
       expiredDate: Date; // 링크 만료 일시
-      params: Record<string, string>; // 추가로 제공할 파라미터
+      command: any;
       afterLinkUrl: string; // 결제 완료 후 이동할 URL
     }
   | PaidPaymentT;
 
 const EXPIRE_TIME_IN_HOURS = 24;
 
-export function createSospesoIssuingPayment(command: {
+export function createSospesoIssuingPayment({
+  sospesoId,
+  now,
+  totalAmount,
+  command,
+}: {
   sospesoId: string;
   now: Date;
+  totalAmount: number;
+  command: SospesoIssuingCommand;
 }): PaymentT {
   return {
-    id: command.sospesoId,
+    id: sospesoId,
     status: "initiated",
     goodsTitle: "코칭 소스페소 1장",
     goodsDescription:
       "1시간 반에서 2시간의 코칭을 수혜자에게 제공하는 소스페소를 구매합니다.",
-    paymentTotalAmount: 0,
-    expiredDate: addHours(command.now, EXPIRE_TIME_IN_HOURS),
-    params: {
-      sospesoId: command.sospesoId,
-    },
+    totalAmount,
+    expiredDate: addHours(now, EXPIRE_TIME_IN_HOURS),
+    command,
     afterLinkUrl: `${env.APP_HOST}${href("소스페소-상세", { sospesoId: command.sospesoId })}`,
   } satisfies PaymentT;
 }

--- a/src/payment/repository.ts
+++ b/src/payment/repository.ts
@@ -1,3 +1,4 @@
+import invariant from "@/invariant.ts";
 import type { PaymentT } from "./domain.ts";
 
 export interface PaymentRepositoryI {
@@ -5,6 +6,7 @@ export interface PaymentRepositoryI {
     paymentId: string,
     update: (payment: PaymentT | undefined) => PaymentT,
   ): Promise<void>;
+  retrievePayment(paymentId: string): Promise<PaymentT>;
 }
 
 export const createFakePaymentRepository = (
@@ -18,6 +20,12 @@ export const createFakePaymentRepository = (
       update: (payment: PaymentT | undefined) => PaymentT,
     ): Promise<void> {
       _fakeState[paymentId] = update(_fakeState[paymentId]);
+    },
+    async retrievePayment(paymentId) {
+      const result = _fakeState[paymentId];
+      invariant(result, "결제가 존재하지 않습니다! : " + paymentId);
+
+      return result;
     },
   } satisfies PaymentRepositoryI;
 };

--- a/src/routing/href.ts
+++ b/src/routing/href.ts
@@ -16,10 +16,10 @@ export function href<RouteKey extends RouteKeys>(
       const result = Object.entries(parsedParams).reduce(
         (path, [key, value]) => {
           if (new RegExp("\\[" + key + "\\]").exec(path)) {
-            return path.replace("[" + key + "]", value);
+            return path.replace("[" + key + "]", encodeURIComponent(value));
           }
 
-          searchParams.set(key, value);
+          searchParams.set(key, encodeURIComponent(value));
           return path;
         },
         route.path,

--- a/src/routing/parseRouteParams.test.ts
+++ b/src/routing/parseRouteParams.test.ts
@@ -27,4 +27,19 @@ describe("parseRouteParams", () => {
       consumerId: TEST_CONSUMER_ID,
     });
   });
+
+  test("URL에 못 들어갈 값들도 처리할 수 있다", () => {
+    const TEST_ID = "#@!TT RST김토끼-=_/+"; // 뛰어쓰기 한글 특수문자 슬래시와 골뱅이 등
+    const path = href("파라미터-테스트", {
+      testId: TEST_ID,
+      q: TEST_ID,
+    });
+
+    const url = new URL(window.origin + path);
+
+    expect(parseRouteParamsFromUrl("파라미터-테스트", url)).toEqual({
+      testId: TEST_ID,
+      q: TEST_ID,
+    });
+  });
 });

--- a/src/routing/parseRouteParams.ts
+++ b/src/routing/parseRouteParams.ts
@@ -8,7 +8,11 @@ export function parseRouteParamsFromUrl<RouteKey extends RouteKeys>(
 ): RouteParams<RouteKey> {
   const route = resolveRoute(routeKey);
 
-  const searchParams = Object.fromEntries(new URLSearchParams(url.search));
+  const searchParams = Object.fromEntries(
+    new URLSearchParams(url.search)
+      .entries()
+      .map(([key, value]) => [key, decodeURIComponent(value)]),
+  );
 
   if ("paramsSchema" in route) {
     const pathKeys = [];
@@ -40,7 +44,7 @@ export function parseRouteParamsFromUrl<RouteKey extends RouteKeys>(
 
     const pathParams = Object.fromEntries(
       pathKeys.map((path, index) => {
-        return [path, pathValues[index]];
+        return [path, decodeURIComponent(pathValues[index]!)];
       }),
     );
 

--- a/src/routing/routes.ts
+++ b/src/routing/routes.ts
@@ -24,6 +24,12 @@ export const routes = {
   "소스페소-발행": {
     path: "/sospeso/issuing",
   },
+  "소스페소-결제": {
+    path: "/payment/[paymentId]",
+    paramsSchema: v.object({
+      paymentId: v.string(),
+    }),
+  },
   "소스페소-상세": {
     path: "/sospeso/[sospesoId]",
     paramsSchema: v.object({
@@ -78,6 +84,13 @@ export const routes = {
   },
   "소스페소-신청완료": {
     path: "/sospeso/applicationSuccess",
+  },
+  "파라미터-테스트": {
+    path: "/test/[testId]",
+    paramsSchema: v.object({
+      testId: v.string(),
+      q: v.string(),
+    }),
   },
 } satisfies Record<string, Route>;
 

--- a/src/sospeso/domain.ts
+++ b/src/sospeso/domain.ts
@@ -55,7 +55,7 @@ export function isConsumed(
   return sospeso.consuming !== undefined;
 }
 
-type SospesoIssuingCommand = {
+export type SospesoIssuingCommand = {
   sospesoId: string;
   issuedAt: Date;
   from: string;

--- a/src/sospeso/fixtures.ts
+++ b/src/sospeso/fixtures.ts
@@ -8,7 +8,7 @@ export const TEST_SOSPESO_ID = "DaLNnQs8nfVgs0";
 export const TEST_ISSUED_AT = new Date("2024-11-09T00:00:00Z");
 
 export const TEST_SOSPESO_LIST_ITEM = {
-  id: generateId(),
+  id: "7pD2z_SkcIWR75",
   from: "탐정토끼",
   to: "퀴어 문화 축제 올 사람",
   issuedAt: TEST_ISSUED_AT,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -44,6 +44,8 @@ export default getViteConfig({
         "src/astro/**",
         "src/routing/navigate.ts",
         "src/adapters/**",
+        "src/lib/**",
+        "src/middleware/**",
       ],
     },
   },


### PR DESCRIPTION
페이플 테스트 결제를 붙였습니다. 소스페소 결제 모델이 들어와서, 발행을 하면 결제 엔티티가 생성되고, 소스페소 결제 페이지로 넘어가서 결제 링크를 생성해서 보여주게 됩니다.

소스페소 issuing은 webhook이 들어오면 webhook을 통해 하게 될 것입니다.

후속 작업
- 페이플에 테스트 웹훅 등록해서 발행 로직 연결하기
- 발행 폼 다듬고 개인정보처리방침과 약관, 환불 규정 등 보여주기
- 환불 로직 만들기
- payment 도 drizzle 로 실제 repository 구현체 만들기