### PR TITLE
소스페소 발행 서비스 추가

### DIFF
--- a/src/services/services.test.ts
+++ b/src/services/services.test.ts
@@ -12,7 +12,7 @@ import {
 } from "@/sospeso/repository.ts";
 
 import { generateNanoId } from "@/adapters/generateId.ts";
-import { sospesoServices } from "./services";
+import { createSospesoServices } from "./services";
 import { TEST_NOW } from "@/actions/fixtures";
 import { SOSPESO_PRICE } from "@/sospeso/constants";
 
@@ -54,8 +54,9 @@ function runSospesoServicesTest(
         sospeso: {},
       });
 
+      const sospesoServices = createSospesoServices(sospesoRepo);
+
       await sospesoServices.issueSospeso({
-        sospesoRepo,
         command: issuingSospeso,
         context: {
           user: {

--- a/src/services/services.test.ts
+++ b/src/services/services.test.ts
@@ -1,0 +1,152 @@
+import { afterAll, describe, expect, test } from "vitest";
+import { drizzle } from "drizzle-orm/libsql";
+import { like } from "drizzle-orm";
+
+import * as schema from "@/adapters/drizzle/schema.ts";
+import { createDrizzleSospesoRepository } from "@/adapters/drizzle/drizzleSospesoRepository.ts";
+import { TEST_ADMIN_USER, TEST_USER, TEST_USER_ID } from "@/auth/fixtures.ts";
+import type { Sospeso } from "@/sospeso/domain.ts";
+import {
+  createFakeSospesoRepository,
+  type SospesoRepositoryI,
+} from "@/sospeso/repository.ts";
+
+import { generateNanoId } from "@/adapters/generateId.ts";
+import { sospesoServices } from "./services";
+import { TEST_NOW } from "@/actions/fixtures";
+import { SOSPESO_PRICE } from "@/sospeso/constants";
+
+const generateId = generateNanoId;
+
+const sospesoId = generateId();
+
+const issuingSospeso = {
+  sospesoId: sospesoId,
+  from: "퀴어 문화 축제 온 사람",
+  to: "퀴어 문화 축제 갔다올 사람",
+  issuerId: TEST_USER_ID,
+  paidAmount: SOSPESO_PRICE,
+  issuedAt: TEST_NOW,
+};
+
+const createSospesoTestRepository = async ({
+  createSospesoRepository,
+  sospeso,
+}: {
+  createSospesoRepository: (
+    initState: Record<string, Sospeso>,
+  ) => Promise<SospesoRepositoryI>;
+  sospeso: Record<string, Sospeso>;
+}) => {
+  return await createSospesoRepository(sospeso);
+};
+
+function runSospesoServicesTest(
+  name: string,
+  createSospesoRepository: (
+    initState: Record<string, Sospeso>,
+  ) => Promise<SospesoRepositoryI>,
+) {
+  describe("sospesoServices: " + name, () => {
+    test("소스페소를 발행할 수 있다.", async () => {
+      const sospesoRepo = await createSospesoTestRepository({
+        createSospesoRepository,
+        sospeso: {},
+      });
+
+      await sospesoServices.issueSospeso({
+        sospesoRepo,
+        command: issuingSospeso,
+        context: {
+          user: {
+            id: TEST_USER_ID,
+            nickname: "김코치",
+            role: "admin",
+          },
+        },
+      });
+
+      const result = await sospesoRepo.retrieveSospesoDetail(
+        issuingSospeso.sospesoId,
+      );
+
+      expect(result?.status).toBe("issued");
+    });
+  });
+}
+
+const testDbReallySeriously = drizzle({
+  schema,
+  logger: false,
+  connection: {
+    url: "file:test.db",
+  },
+});
+
+async function createDrizzleTestSospesoRepository(
+  initState: Record<string, Sospeso>,
+) {
+  await testDbReallySeriously
+    .insert(schema.user)
+    .values(TEST_USER)
+    .onConflictDoNothing();
+  await testDbReallySeriously
+    .insert(schema.user)
+    .values(TEST_ADMIN_USER)
+    .onConflictDoNothing();
+
+  const repo = createDrizzleSospesoRepository(testDbReallySeriously);
+
+  // prod db에 실행하면 절대 안 됨
+  await testDbReallySeriously.delete(schema.sospesoConsuming).all();
+  await testDbReallySeriously.delete(schema.sospesoApplication).all();
+  await testDbReallySeriously.delete(schema.sospesoIssuing).all();
+  await testDbReallySeriously.delete(schema.sospeso).all();
+
+  for (const sospeso of Object.values(initState)) {
+    await repo.updateOrSave(sospeso.id, () => sospeso);
+  }
+
+  return repo;
+}
+
+afterAll(async () => {
+  const testDbReallySeriously = drizzle({
+    schema,
+    logger: false,
+    connection: {
+      url: "file:test.db",
+    },
+  });
+
+  // // prod db에 실행하면 절대 안 됨
+  // // sospeso
+  await testDbReallySeriously.delete(schema.sospesoConsuming).all();
+  await testDbReallySeriously.delete(schema.sospesoApplication).all();
+  await testDbReallySeriously.delete(schema.sospesoIssuing).all();
+  await testDbReallySeriously.delete(schema.sospeso).all();
+  // payment
+  await testDbReallySeriously.delete(schema.payment).all();
+
+  await testDbReallySeriously
+    .delete(schema.user)
+    .where(like(schema.user.email, "%@test.kr"))
+    .run();
+
+  // await createDrizzleTestSospesoRepository(
+  //   Object.fromEntries(
+  //     Array.from({ length: 100 }).map((_, i) => {
+  //       const sospeso = randomSospeso(
+  //         pick(["issued", "issued", "consumed", "consumed", "pending"]),
+  //       );
+  //       return [sospeso.id, sospeso];
+  //     }),
+  //   ),
+  // );
+});
+
+runSospesoServicesTest("drizzle sqlite", createDrizzleTestSospesoRepository);
+
+runSospesoServicesTest("fake", async (initState) =>
+  createFakeSospesoRepository(initState),
+);

--- a/src/services/services.test.ts
+++ b/src/services/services.test.ts
@@ -1,10 +1,5 @@
-import { afterAll, describe, expect, test } from "vitest";
-import { drizzle } from "drizzle-orm/libsql";
-import { like } from "drizzle-orm";
-
-import * as schema from "@/adapters/drizzle/schema.ts";
-import { createDrizzleSospesoRepository } from "@/adapters/drizzle/drizzleSospesoRepository.ts";
-import { TEST_ADMIN_USER, TEST_USER, TEST_USER_ID } from "@/auth/fixtures.ts";
+import { describe, expect, test } from "vitest";
+import { TEST_USER_ID } from "@/auth/fixtures.ts";
 import type { Sospeso } from "@/sospeso/domain.ts";
 import {
   createFakeSospesoRepository,
@@ -20,25 +15,16 @@ const generateId = generateNanoId;
 
 const sospesoId = generateId();
 
-const issuingSospeso = {
-  sospesoId: sospesoId,
-  from: "퀴어 문화 축제 온 사람",
-  to: "퀴어 문화 축제 갔다올 사람",
-  issuerId: TEST_USER_ID,
-  paidAmount: SOSPESO_PRICE,
-  issuedAt: TEST_NOW,
-};
-
-const createSospesoTestRepository = async ({
-  createSospesoRepository,
-  sospeso,
-}: {
-  createSospesoRepository: (
-    initState: Record<string, Sospeso>,
-  ) => Promise<SospesoRepositoryI>;
-  sospeso: Record<string, Sospeso>;
-}) => {
-  return await createSospesoRepository(sospeso);
+const event = {
+  type: "paymentComplete",
+  command: {
+    sospesoId: sospesoId,
+    from: "퀴어 문화 축제 온 사람",
+    to: "퀴어 문화 축제 갔다올 사람",
+    issuerId: TEST_USER_ID,
+    paidAmount: SOSPESO_PRICE,
+    issuedAt: TEST_NOW,
+  }
 };
 
 function runSospesoServicesTest(
@@ -49,104 +35,21 @@ function runSospesoServicesTest(
 ) {
   describe("sospesoServices: " + name, () => {
     test("소스페소를 발행할 수 있다.", async () => {
-      const sospesoRepo = await createSospesoTestRepository({
-        createSospesoRepository,
-        sospeso: {},
-      });
+      const command = event.command;
 
+      const sospesoRepo = await createSospesoRepository({});
       const sospesoServices = createSospesoServices(sospesoRepo);
 
-      await sospesoServices.issueSospeso({
-        command: issuingSospeso,
-        context: {
-          user: {
-            id: TEST_USER_ID,
-            nickname: "김코치",
-            role: "admin",
-          },
-        },
-      });
+      await sospesoServices.issueSospeso(command);
 
       const result = await sospesoRepo.retrieveSospesoDetail(
-        issuingSospeso.sospesoId,
+        command.sospesoId,
       );
 
       expect(result?.status).toBe("issued");
     });
   });
 }
-
-const testDbReallySeriously = drizzle({
-  schema,
-  logger: false,
-  connection: {
-    url: "file:test.db",
-  },
-});
-
-async function createDrizzleTestSospesoRepository(
-  initState: Record<string, Sospeso>,
-) {
-  await testDbReallySeriously
-    .insert(schema.user)
-    .values(TEST_USER)
-    .onConflictDoNothing();
-  await testDbReallySeriously
-    .insert(schema.user)
-    .values(TEST_ADMIN_USER)
-    .onConflictDoNothing();
-
-  const repo = createDrizzleSospesoRepository(testDbReallySeriously);
-
-  // prod db에 실행하면 절대 안 됨
-  await testDbReallySeriously.delete(schema.sospesoConsuming).all();
-  await testDbReallySeriously.delete(schema.sospesoApplication).all();
-  await testDbReallySeriously.delete(schema.sospesoIssuing).all();
-  await testDbReallySeriously.delete(schema.sospeso).all();
-
-  for (const sospeso of Object.values(initState)) {
-    await repo.updateOrSave(sospeso.id, () => sospeso);
-  }
-
-  return repo;
-}
-
-afterAll(async () => {
-  const testDbReallySeriously = drizzle({
-    schema,
-    logger: false,
-    connection: {
-      url: "file:test.db",
-    },
-  });
-
-  // // prod db에 실행하면 절대 안 됨
-  // // sospeso
-  await testDbReallySeriously.delete(schema.sospesoConsuming).all();
-  await testDbReallySeriously.delete(schema.sospesoApplication).all();
-  await testDbReallySeriously.delete(schema.sospesoIssuing).all();
-  await testDbReallySeriously.delete(schema.sospeso).all();
-  // payment
-  await testDbReallySeriously.delete(schema.payment).all();
-
-  await testDbReallySeriously
-    .delete(schema.user)
-    .where(like(schema.user.email, "%@test.kr"))
-    .run();
-
-  // await createDrizzleTestSospesoRepository(
-  //   Object.fromEntries(
-  //     Array.from({ length: 100 }).map((_, i) => {
-  //       const sospeso = randomSospeso(
-  //         pick(["issued", "issued", "consumed", "consumed", "pending"]),
-  //       );
-  //       return [sospeso.id, sospeso];
-  //     }),
-  //   ),
-  // );
-});
-
-runSospesoServicesTest("drizzle sqlite", createDrizzleTestSospesoRepository);
 
 runSospesoServicesTest("fake", async (initState) =>
   createFakeSospesoRepository(initState),

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -2,31 +2,31 @@ import invariant from "@/invariant";
 import { issueSospeso, type SospesoIssuingCommand } from "@/sospeso/domain";
 import type { SospesoRepositoryI } from "@/sospeso/repository";
 
-export const sospesoServices = {
-  issueSospeso: async ({
-    sospesoRepo,
-    command,
-    context: { user },
-  }: {
-    sospesoRepo: SospesoRepositoryI;
-    command: SospesoIssuingCommand;
-    context: {
-      user?: {
-        id: string;
-        nickname: string;
-        role: "user" | "admin";
+export function createSospesoServices(sospesoRepo: SospesoRepositoryI) {
+  return {
+    issueSospeso: async ({
+      command,
+      context: { user },
+    }: {
+      command: SospesoIssuingCommand;
+      context: {
+        user?: {
+          id: string;
+          nickname: string;
+          role: "user" | "admin";
+        };
       };
-    };
-  }) => {
-    invariant(user, "로그인을 해야 합니다");
-    const applicantId = user.id;
+    }) => {
+      invariant(user, "로그인을 해야 합니다");
+      const applicantId = user.id;
 
-    invariant(applicantId, "로그인해야 소스페소를 발행할 수 있어요!");
+      invariant(applicantId, "로그인해야 소스페소를 발행할 수 있어요!");
 
-    await sospesoRepo.updateOrSave(command.sospesoId, () => {
-      const issuedSospeso = issueSospeso(command);
+      await sospesoRepo.updateOrSave(command.sospesoId, () => {
+        const issuedSospeso = issueSospeso(command);
 
-      return issuedSospeso;
-    });
-  },
-};
+        return issuedSospeso;
+      });
+    },
+  };
+}

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1,0 +1,25 @@
+import { sospesoRepo } from "@/actions/actions";
+import invariant from "@/invariant";
+import { issueSospeso, type SospesoIssuingCommand } from "@/sospeso/domain";
+
+export const sospesoServices = {
+  issueSospeso: async (
+    command: SospesoIssuingCommand,
+    user?: {
+      id: string;
+      nickname: string;
+      role: "user" | "admin";
+    },
+  ) => {
+    invariant(user, "로그인을 해야 합니다");
+    const applicantId = user.id;
+
+    invariant(applicantId, "로그인해야 소스페소를 발행할 수 있어요!");
+
+    await sospesoRepo.updateOrSave(command.sospesoId, () => {
+      const issuedSospeso = issueSospeso(command);
+
+      return issuedSospeso;
+    });
+  },
+};

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1,16 +1,23 @@
-import { sospesoRepo } from "@/actions/actions";
 import invariant from "@/invariant";
 import { issueSospeso, type SospesoIssuingCommand } from "@/sospeso/domain";
+import type { SospesoRepositoryI } from "@/sospeso/repository";
 
 export const sospesoServices = {
-  issueSospeso: async (
-    command: SospesoIssuingCommand,
-    user?: {
-      id: string;
-      nickname: string;
-      role: "user" | "admin";
-    },
-  ) => {
+  issueSospeso: async ({
+    sospesoRepo,
+    command,
+    context: { user },
+  }: {
+    sospesoRepo: SospesoRepositoryI;
+    command: SospesoIssuingCommand;
+    context: {
+      user?: {
+        id: string;
+        nickname: string;
+        role: "user" | "admin";
+      };
+    };
+  }) => {
     invariant(user, "로그인을 해야 합니다");
     const applicantId = user.id;
 

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1,27 +1,9 @@
-import invariant from "@/invariant";
 import { issueSospeso, type SospesoIssuingCommand } from "@/sospeso/domain";
 import type { SospesoRepositoryI } from "@/sospeso/repository";
 
 export function createSospesoServices(sospesoRepo: SospesoRepositoryI) {
   return {
-    issueSospeso: async ({
-      command,
-      context: { user },
-    }: {
-      command: SospesoIssuingCommand;
-      context: {
-        user?: {
-          id: string;
-          nickname: string;
-          role: "user" | "admin";
-        };
-      };
-    }) => {
-      invariant(user, "로그인을 해야 합니다");
-      const applicantId = user.id;
-
-      invariant(applicantId, "로그인해야 소스페소를 발행할 수 있어요!");
-
+    issueSospeso: async (command: SospesoIssuingCommand) => {
       await sospesoRepo.updateOrSave(command.sospesoId, () => {
         const issuedSospeso = issueSospeso(command);
 

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -25,6 +25,7 @@ export default defineWorkspace([
     test: {
       include: [
         "src/actions/**/*.test.ts",
+        "src/services/**/*.test.ts",
         "src/sospeso/**/*.test.ts",
         "src/auth/**/*.test.ts",
         "src/payment/**/*.test.ts",


### PR DESCRIPTION
- 소스페소 발행 서비스를 추가했습니다.
- 서비스 객체를 생성하는 함수를 두고 레포지토리를 넘겨주도록 구현했습니다.
- 바꿀 부분 남겨주시면 바로 반영하거나 다음 작업으로 진행하겠습니다 !

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a service for managing "Sospeso" operations, allowing users to issue Sospeso records.
	- Enhanced testing framework for Sospeso services to validate functionality and ensure reliability.

- **Documentation**
	- Updated test configuration to include new service tests for comprehensive coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->