### PR TITLE
소스페소 결제 완료 및 취소

### DIFF
--- a/src/actions/actions.test.ts
+++ b/src/actions/actions.test.ts
@@ -25,8 +25,10 @@ import {
   createFakePaymentRepository,
   type PaymentRepositoryI,
 } from "@/payment/repository.ts";
-import type { Payment } from "@/payment/domain.ts";
+import { cancelPayment, createSospesoIssuingPayment, type Payment } from "@/payment/domain.ts";
 import { createDrizzlePaymentRepository } from "@/adapters/drizzle/drizzlePaymentRepository.ts";
+import invariant from "../invariant.ts";
+import { EXAMPLE_PAYMENT_PAYLOAD } from "../payment/fixtures.ts";
 
 const generateId = generateNanoId;
 
@@ -81,6 +83,78 @@ function runSospesoActionsTest(
       expect(paymentLink).toBe(
         "https://democpay.payple.kr/php/link/?SID=MTI6MTU4NDYwNzI4Mg?id=7pD2z_SkcIWR75",
       );
+    });
+
+    test("결제를 완료할 수 있다", async () => {
+      const { actionServer, paymentRepo } = await createTestActionServer({
+        sospeso: {},
+        payment: {
+          [TEST_SOSPESO_LIST_ITEM.id]: createSospesoIssuingPayment({
+            sospesoId: TEST_SOSPESO_LIST_ITEM.id,
+            now: TEST_NOW,
+            totalAmount: 80000,
+            command: {
+              sospesoId: TEST_SOSPESO_LIST_ITEM.id,
+              issuedAt: TEST_NOW,
+              from: TEST_SOSPESO_LIST_ITEM.from,
+              to: TEST_SOSPESO_LIST_ITEM.to,
+              issuerId: TEST_USER_ID,
+              paidAmount: 80000,
+            },
+          }),
+        },
+      });
+
+      await actionServer.completeSospesoPayment(
+        {
+          sospesoId: TEST_SOSPESO_LIST_ITEM.id,
+          paymentResult: EXAMPLE_PAYMENT_PAYLOAD,
+        },
+        ADMIN_CONTEXT,
+      );
+
+      const payment = await paymentRepo.retrievePayment(TEST_SOSPESO_LIST_ITEM.id);
+
+      expect(payment?.status).toBe("paid");
+    });
+
+    test("결제를 취소할 수 있다", async () => {
+      const { actionServer, paymentRepo } = await createTestActionServer({
+        sospeso: {},
+        payment: {
+          [TEST_SOSPESO_LIST_ITEM.id]: createSospesoIssuingPayment({
+            sospesoId: TEST_SOSPESO_LIST_ITEM.id,
+            now: TEST_NOW,
+            totalAmount: 80000,
+            command: {
+              sospesoId: TEST_SOSPESO_LIST_ITEM.id,
+              issuedAt: TEST_NOW,
+              from: TEST_SOSPESO_LIST_ITEM.from,
+              to: TEST_SOSPESO_LIST_ITEM.to,
+              issuerId: TEST_USER_ID,
+              paidAmount: 80000,
+            },
+          }),
+        },
+      });
+
+      await actionServer.completeSospesoPayment(
+        {
+          sospesoId: TEST_SOSPESO_LIST_ITEM.id,
+          paymentResult: EXAMPLE_PAYMENT_PAYLOAD,
+        }
+      );
+
+      await actionServer.cancelSospesoPayment(
+        {
+          sospesoId: TEST_SOSPESO_LIST_ITEM.id,
+        },
+        ADMIN_CONTEXT,
+      );
+
+      const payment = await paymentRepo.retrievePayment(TEST_SOSPESO_LIST_ITEM.id);
+
+      expect(payment?.status).toBe("cancelled");
     });
 
     test("소스페소에 신청할 수 있다", async () => {

--- a/src/adapters/drizzle/drizzlePaymentRepository.ts
+++ b/src/adapters/drizzle/drizzlePaymentRepository.ts
@@ -8,7 +8,7 @@ import invariant from "@/invariant.ts";
 
 const paymentSchema = v.object({
   id: v.string(),
-  status: v.picklist(["initiated", "paid"]),
+  status: v.picklist(["initiated", "paid", "cancelled"]),
   goodsTitle: v.string(),
   goodsDescription: v.string(),
   totalAmount: v.pipe(v.number(), v.integer(), v.minValue(1)),

--- a/src/payment/domain.test.ts
+++ b/src/payment/domain.test.ts
@@ -71,7 +71,7 @@ describe("payment", () => {
       command: SOSPESO_ISSUING_COMMAND,
     });
     const paidPayment = completePayment(payment, EXAMPLE_PAYMENT_PAYLOAD);
-    const result = cancelPayment(paidPayment, EXAMPLE_PAYMENT_PAYLOAD);
+    const result = cancelPayment(paidPayment);
     expect(result.status).toStrictEqual("cancelled");
   });
 });

--- a/src/payment/domain.test.ts
+++ b/src/payment/domain.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { completePayment, createSospesoIssuingPayment, isPaid } from "./domain";
+import { cancelPayment, completePayment, createSospesoIssuingPayment, isPaid } from "./domain";
 import { EXAMPLE_PAYMENT_PAYLOAD } from "./fixtures";
 import { TEST_SOSPESO_ID, TEST_SOSPESO_LIST_ITEM } from "@/sospeso/fixtures";
 import { TEST_USER_ID } from "@/auth/fixtures";
@@ -61,5 +61,17 @@ describe("payment", () => {
     });
 
     expect(isPaid(result)).toBe(true);
+  });
+
+  test("결제를 취소할 수 있다", () => {
+    const payment = createSospesoIssuingPayment({
+      sospesoId: TEST_PAYMENT_ID,
+      now: NOW,
+      totalAmount: 80000,
+      command: SOSPESO_ISSUING_COMMAND,
+    });
+    const paidPayment = completePayment(payment, EXAMPLE_PAYMENT_PAYLOAD);
+    const result = cancelPayment(paidPayment, EXAMPLE_PAYMENT_PAYLOAD);
+    expect(result.status).toStrictEqual("cancelled");
   });
 });

--- a/src/payment/domain.ts
+++ b/src/payment/domain.ts
@@ -79,13 +79,11 @@ export function completePayment(
 }
 
 export function cancelPayment(
-  payment: Payment,
-  paymentResult: Record<string, string>,
+  paidPayment: PaidPayment,
 ): CancelledPayment {
   return {
-    ...payment,
+    ...paidPayment,
     status: "cancelled",
-    paymentResult,
   } satisfies CancelledPayment;
 }
 

--- a/src/payment/domain.ts
+++ b/src/payment/domain.ts
@@ -15,6 +15,18 @@ export type PaidPayment = {
   paymentResult: Record<string, string>; // 결제 결과 원본
 };
 
+export type CancelledPayment = {
+  id: string;
+  status: "cancelled";
+  goodsTitle: string; // 상품 이름
+  goodsDescription: string; // 상품 설명
+  totalAmount: number; // 상품의 가격
+  expiredDate: Date; // 링크 만료 일시
+  command: any;
+  afterLinkUrl: string; // 결제 완료 후 이동할 URL
+  paymentResult: Record<string, string>; // 결제 결과 원본
+};
+
 export type Payment =
   | {
       id: string;
@@ -26,7 +38,8 @@ export type Payment =
       command: any;
       afterLinkUrl: string; // 결제 완료 후 이동할 URL
     }
-  | PaidPayment;
+  | PaidPayment
+  | CancelledPayment;
 
 const EXPIRE_TIME_IN_HOURS = 24;
 
@@ -65,6 +78,21 @@ export function completePayment(
   } satisfies PaidPayment;
 }
 
+export function cancelPayment(
+  payment: Payment,
+  paymentResult: Record<string, string>,
+): CancelledPayment {
+  return {
+    ...payment,
+    status: "cancelled",
+    paymentResult,
+  } satisfies CancelledPayment;
+}
+
 export function isPaid(payment: Payment): payment is PaidPayment {
   return payment.status === "paid";
+}
+
+export function isCancelled(payment: Payment): payment is CancelledPayment {
+  return payment.status === "cancelled";
 }


### PR DESCRIPTION
### 남은 부분
- 페이플 API 연결: 페이플 API 문서상으로 유추하건대 결제 수단(카드, 계좌이체)마다 별도의 결제 취소 엔드포인트가 존재하는것 같다.

### 논의가 필요한 부분
- 링크결제가 완료되면 웹훅으로 결제 완료 노티피케이션을 받아서 결제 완료 처리를 해야할지? 아니면 어드민이 수동으로?
- 결제 완료와 소스페소 발행을 연결시키는 것은 어드민이 수동으로? 아니면 자동으로?

