### PR TITLE
feat: 전화번호 필드

### DIFF
--- a/src/components/auth/SignUpForm.tsx
+++ b/src/components/auth/SignUpForm.tsx
@@ -7,6 +7,7 @@ import { Checkbox } from "@/shared/form/Checkbox.tsx";
 import { emailSchema, passwordSchema, phoneSchema } from "@/auth/schema";
 import { Link } from "@/routing/Link";
 import { PasswordInput } from "@/shared/form/PasswordInput";
+import { PhoneField } from '@/shared/form/PhoneField';
 
 const signUpSchema = v.pipe(
   v.object({
@@ -92,7 +93,7 @@ export function SignUpForm() {
             autoComplete="name"
             placeholder="홍길동"
           />
-          <TextField
+          <PhoneField
             label="전화번호"
             name="phone"
             placeholder="010-1234-5678"

--- a/src/components/auth/UpdateUserForm.tsx
+++ b/src/components/auth/UpdateUserForm.tsx
@@ -4,6 +4,7 @@ import { Form } from "@/shared/form/Form";
 import { TextField } from "@/shared/form/TextField";
 import { createSafeEvent } from "@/event/SafeEventBus";
 import { phoneSchema } from "@/auth/schema";
+import { PhoneField } from '@/shared/form/PhoneField';
 
 const updateUserSchema = v.object({
   name: v.pipe(v.string(), v.minLength(1, "실명이 꼭 있어야 해요")),
@@ -45,13 +46,13 @@ export function UpdateUserForm({
             autoComplete="name"
             placeholder="홍길동"
           />
-          <TextField
+          <TextField label="별명" name="nickname" placeholder="다정한 토끼" />
+          <PhoneField
             label="전화번호"
             name="phone"
             placeholder="010-1234-5678"
             autoComplete="tel-national"
           />
-          <TextField label="별명" name="nickname" placeholder="다정한 토끼" />
           <button className="btn btn-primary w-full" type="submit">
             프로필 수정하기
           </button>

--- a/src/shared/form/PhoneField.tsx
+++ b/src/shared/form/PhoneField.tsx
@@ -1,0 +1,56 @@
+import clsx from "clsx";
+import { useId, type ComponentProps } from "react";
+import { useController, useFormContext } from "react-hook-form";
+import { SimpleErrorMessage } from "./SimpleErrorMessage";
+import { formatPhoneNumber } from './phone';
+
+export function PhoneField<InputT extends Record<string, any>>({
+  label,
+  name,
+  className,
+  ...props
+}: {
+  label: string;
+  name: keyof InputT & string;
+} & Omit<ComponentProps<"input">, "onChange" | "onBlur" | "value" | "maxLength" | "type">) {
+  const { control } = useFormContext();
+  const {
+    field,
+    fieldState: { error },
+  } = useController({
+    name,
+    control,
+    rules: { required: true },
+  });
+  const errorId = useId();
+  const isInvalid = error?.message !== undefined;
+
+  return (
+    <div>
+      <label className="flex flex-col items-start">
+        {label}
+        <input
+          {...props}
+          type="tel"
+          role="textbox"
+          name={field.name} // send down the input name
+          className={clsx(
+            "input input-bordered aria-[invalid=true]:input-error w-full",
+            className,
+          )}
+          onChange={event => {
+            field.onChange(formatPhoneNumber(event.target.value))
+          }}
+          onBlur={field.onBlur} // notify when input is touched/blur
+          value={formatPhoneNumber(field.value  ?? "")} // input value
+          maxLength={13}
+          ref={field.ref} // send input ref, so we can focus on input when error appear
+          aria-invalid={isInvalid}
+          aria-describedby={isInvalid ? errorId : undefined}
+          aria-errormessage={isInvalid ? errorId : undefined}
+        />
+      </label>
+      <SimpleErrorMessage id={errorId} error={error} />
+    </div>
+  );
+}

--- a/src/shared/form/phone.test.ts
+++ b/src/shared/form/phone.test.ts
@@ -10,12 +10,15 @@ describe("formatPhoneNumber", () => {
     expect(formatPhoneNumber("0319231733")).toBe("031-923-1733");
   });
 
-  it("should format Seoul numbers with 8 digits", () => {
-    expect(formatPhoneNumber("02111222")).toBe("021-1122-2");
-  });
-
-  it("should format Seoul numbers with 9 digits", () => {
+  it("should format Seoul numbers shorter than 9 digits", () => {
+    expect(formatPhoneNumber("02")).toBe("02");
+    expect(formatPhoneNumber("021")).toBe("02-1");
+    expect(formatPhoneNumber("02111")).toBe("02-111");
+    expect(formatPhoneNumber("021112")).toBe("02-111-2");
+    expect(formatPhoneNumber("0211122")).toBe("02-111-22");
+    expect(formatPhoneNumber("02111222")).toBe("02-111-222");
     expect(formatPhoneNumber("021112222")).toBe("02-111-2222");
+    expect(formatPhoneNumber("0211122222")).toBe("02-1112-2222");
   });
 
   it("should handle numbers with existing hyphens", () => {

--- a/src/shared/form/phone.test.ts
+++ b/src/shared/form/phone.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { formatPhoneNumber } from "./phone.ts";
+
+describe("formatPhoneNumber", () => {
+  it("should format domestic mobile numbers", () => {
+    expect(formatPhoneNumber("01048271733")).toBe("010-4827-1733");
+  });
+
+  it("should format regional numbers", () => {
+    expect(formatPhoneNumber("0319231733")).toBe("031-923-1733");
+  });
+
+  it("should format Seoul numbers with 8 digits", () => {
+    expect(formatPhoneNumber("02111222")).toBe("021-1122-2");
+  });
+
+  it("should format Seoul numbers with 9 digits", () => {
+    expect(formatPhoneNumber("021112222")).toBe("02-111-2222");
+  });
+
+  it("should handle numbers with existing hyphens", () => {
+    expect(formatPhoneNumber("010-4827-1733")).toBe("010-4827-1733");
+  });
+
+  it("should handle numbers with spaces", () => {
+    expect(formatPhoneNumber("010 4827 1733")).toBe("010-4827-1733");
+  });
+});

--- a/src/shared/form/phone.ts
+++ b/src/shared/form/phone.ts
@@ -11,14 +11,19 @@ export function formatPhoneNumber(value: string): string {
 
   invariant(cleaned.length <= 11, "전화번호는 11자 이하여야 합니다 : " + cleaned)
 
+  
+  if(cleaned.startsWith("02")) {
+    if (cleaned.length <= 5) return cleaned.replace(/(\d{2})(\d{1,3})/, "$1-$2")
+    if (cleaned.length <= 9) return cleaned.replace(/(\d{2})(\d{3})(\d{1,4})/, "$1-$2-$3")
+    return cleaned.replace(/(\d{2})(\d{4})(\d{4})/, "$1-$2-$3")
+  }
+
   if(cleaned.length <= 7) {
     return cleaned.replace(/(\d{3})(\d{1,4})/, "$1-$2")
   }
-  if(cleaned.length < 9) {
+
+  if(cleaned.length <= 9) {
     return cleaned.replace(/(\d{3})(\d{4})(\d{1,3})/, "$1-$2-$3")
-  }
-  if(cleaned.length === 9 && cleaned.startsWith("02")) {
-    return cleaned.replace(/(\d{2})(\d{3})(\d{4})/, "$1-$2-$3")
   }
   if(cleaned.length === 10) {
     return cleaned.replace(/(\d{3})(\d{3})(\d{4})/, "$1-$2-$3")

--- a/src/shared/form/phone.ts
+++ b/src/shared/form/phone.ts
@@ -1,0 +1,27 @@
+import invariant from '@/invariant';
+
+/**
+ * Formats a phone number string into a Korean phone number format
+ * @param value The input phone number string
+ * @returns Formatted phone number string
+ */
+export function formatPhoneNumber(value: string): string {
+  // Remove any non-digit characters
+  const cleaned = value.replace(/\D/g, "");
+
+  invariant(cleaned.length <= 11, "전화번호는 11자 이하여야 합니다 : " + cleaned)
+
+  if(cleaned.length <= 7) {
+    return cleaned.replace(/(\d{3})(\d{1,4})/, "$1-$2")
+  }
+  if(cleaned.length < 9) {
+    return cleaned.replace(/(\d{3})(\d{4})(\d{1,3})/, "$1-$2-$3")
+  }
+  if(cleaned.length === 9 && cleaned.startsWith("02")) {
+    return cleaned.replace(/(\d{2})(\d{3})(\d{4})/, "$1-$2-$3")
+  }
+  if(cleaned.length === 10) {
+    return cleaned.replace(/(\d{3})(\d{3})(\d{4})/, "$1-$2-$3")
+  }
+  return cleaned.replace(/(\d{3})(\d{4})(\d{4})/, "$1-$2-$3")
+}

--- a/src/stories/auth/UpdateUserForm.stories.tsx
+++ b/src/stories/auth/UpdateUserForm.stories.tsx
@@ -1,0 +1,19 @@
+import { UpdateUserForm } from "@/components/auth/UpdateUserForm.tsx";
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof UpdateUserForm> = {
+  component: UpdateUserForm,
+};
+
+export default meta;
+type Story = StoryObj<typeof UpdateUserForm>;
+
+export const Base: Story = {
+  args: {
+    user: {
+      name: "김토끼",
+      nickname: "손님",
+      phone: ""
+    }
+  },
+};


### PR DESCRIPTION
- 전화번호를 포맷하는 순수함수를 만들었습니다
- 아직 국제 번호는 지원하지 않고, - 제외하고 11글자, -포함 13글자만 허용합니다.
- 이를 react hook form 과 연결한 PhoneField를 만들었습니다.
  - 지금은 TextField나 PhoneField가 react-hook-form 과 강결합되어 있는데요. 디자인 시스템과, 편리하게 React-hook-form을 연결한 컴포넌트를 분리하는 일은 나중으로 미루려 합니다.
  - 회원가입과 계정 정보 변경에 이를 적용했습니다. 기존의 테스트도 똑같이 통과합니다.
  - 계정 정보 변경 폼의 스토리북도 만들었습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a new `PhoneField` component for phone number input in both the Sign-Up and Update User forms, enhancing user experience with improved formatting and validation.
  
- **Bug Fixes**
  - Adjusted the order of fields in the Update User form for better usability.

- **Tests**
  - Added a comprehensive test suite for the `formatPhoneNumber` function to ensure accurate phone number formatting across various scenarios.

- **Documentation**
  - Created Storybook configuration for the `UpdateUserForm` component to facilitate visualization and testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->