### PR TITLE
모바일에서 보이는 소스페소 목록 디자인 구현

### DIFF
--- a/src/components/SospesoCardList.test.tsx
+++ b/src/components/SospesoCardList.test.tsx
@@ -4,19 +4,22 @@ import { queryTL } from "@/siheom/queryTL.ts";
 import { expectTL } from "@/siheom/expectTL.ts";
 import { TEST_SOSPESO_LIST_ITEM } from "@/sospeso/fixtures";
 import { SospesoCardList } from "./SospesoCardList";
+import { href } from "@/routing/href";
 
 describe("SospesoCardList", () => {
-  test.todo("링크를 보여준다 (또는) 클릭하면 상세 페이지로 이동한다.");
-
   test("목록에서 소스페소의 기본 정보를 볼 수 있다", async () => {
     renderTL(<SospesoCardList sospesoList={[TEST_SOSPESO_LIST_ITEM]} />);
 
+    await expectTL(queryTL.link(/FROM/)).toHaveAttribute(
+      "href",
+      href("소스페소-상세", { sospesoId: TEST_SOSPESO_LIST_ITEM.id }),
+    );
     await expectTL(queryTL.text("탐정토끼")).toBeVisible();
     await expectTL(queryTL.text("퀴어 문화 축제 올 사람")).toBeVisible();
     await expectTL(queryTL.text("2024년 11월 9일")).toBeVisible();
   });
 
-  test("신청한 사람이 있다면 '신청자 있음' 문구를 보여준다.", async () => {
+  test("신청자가 있는 소스페소라면 '신청자 있음' 문구를 보여준다.", async () => {
     renderTL(
       <SospesoCardList
         sospesoList={[{ ...TEST_SOSPESO_LIST_ITEM, status: "pending" }]}
@@ -25,7 +28,7 @@ describe("SospesoCardList", () => {
     await expectTL(queryTL.text("신청자 있음")).toBeVisible();
   });
 
-  test("사용한 소스페소라면 '사용함' 문구를 보여준다.", async () => {
+  test("이미 사용한 소스페소라면 '사용함' 문구를 보여준다.", async () => {
     renderTL(
       <SospesoCardList
         sospesoList={[{ ...TEST_SOSPESO_LIST_ITEM, status: "consumed" }]}

--- a/src/components/SospesoCardList.test.tsx
+++ b/src/components/SospesoCardList.test.tsx
@@ -1,0 +1,36 @@
+import { renderTL } from "@/siheom/renderTL.tsx";
+import { describe, test } from "vitest";
+import { queryTL } from "@/siheom/queryTL.ts";
+import { expectTL } from "@/siheom/expectTL.ts";
+import { TEST_SOSPESO_LIST_ITEM } from "@/sospeso/fixtures";
+import { SospesoCardList } from "./SospesoCardList";
+
+describe("SospesoCardList", () => {
+  test.todo("링크를 보여준다 (또는) 클릭하면 상세 페이지로 이동한다.");
+
+  test("목록에서 소스페소의 기본 정보를 볼 수 있다", async () => {
+    renderTL(<SospesoCardList sospesoList={[TEST_SOSPESO_LIST_ITEM]} />);
+
+    await expectTL(queryTL.text("탐정토끼")).toBeVisible();
+    await expectTL(queryTL.text("퀴어 문화 축제 올 사람")).toBeVisible();
+    await expectTL(queryTL.text("2024년 11월 9일")).toBeVisible();
+  });
+
+  test("신청한 사람이 있다면 '신청자 있음' 문구를 보여준다.", async () => {
+    renderTL(
+      <SospesoCardList
+        sospesoList={[{ ...TEST_SOSPESO_LIST_ITEM, status: "pending" }]}
+      />,
+    );
+    await expectTL(queryTL.text("신청자 있음")).toBeVisible();
+  });
+
+  test("사용한 소스페소라면 '사용함' 문구를 보여준다.", async () => {
+    renderTL(
+      <SospesoCardList
+        sospesoList={[{ ...TEST_SOSPESO_LIST_ITEM, status: "consumed" }]}
+      />,
+    );
+    await expectTL(queryTL.text("사용함")).toBeVisible();
+  });
+});

--- a/src/components/SospesoCardList.test.tsx
+++ b/src/components/SospesoCardList.test.tsx
@@ -10,13 +10,12 @@ describe("SospesoCardList", () => {
   test("목록에서 소스페소의 기본 정보를 볼 수 있다", async () => {
     renderTL(<SospesoCardList sospesoList={[TEST_SOSPESO_LIST_ITEM]} />);
 
-    await expectTL(queryTL.link(/FROM/)).toHaveAttribute(
+    await expectTL(queryTL.link(/FROM. 탐정토끼/)).toHaveAttribute(
       "href",
       href("소스페소-상세", { sospesoId: TEST_SOSPESO_LIST_ITEM.id }),
     );
-    await expectTL(queryTL.text("탐정토끼")).toBeVisible();
-    await expectTL(queryTL.text("퀴어 문화 축제 올 사람")).toBeVisible();
-    await expectTL(queryTL.text("2024년 11월 9일")).toBeVisible();
+    await expectTL(queryTL.heading("TO.퀴어 문화 축제 올 사람")).toBeVisible();
+    await expectTL(queryTL.time("발행일")).toHaveText("2024년 11월 9일");
   });
 
   test("신청자가 있는 소스페소라면 '신청자 있음' 문구를 보여준다.", async () => {

--- a/src/components/SospesoCardList.tsx
+++ b/src/components/SospesoCardList.tsx
@@ -14,26 +14,34 @@ export function SospesoCardList({
   }[];
 }) {
   return (
-    <div className="flex flex-col gap-3 ">
+    <div className="flex flex-col gap-3" role="list">
       {sospesoList.map((sospeso) => (
         <Link
           routeKey="소스페소-상세"
           params={{ sospesoId: sospeso.id }}
           key={sospeso.id}
         >
-          <div className="border border-black p-2.5 relative">
+          <div
+            className="border border-black p-2.5 relative"
+            role="listitem"
+            aria-labelledby={`to-${sospeso.to}`}
+          >
             <div className="flex items-center mb-6">
               <span className="mr-[9px] font-bold">FROM.</span>
               <span>{sospeso.from}</span>
-              <span className="ml-auto text-[11px]">
+              <time
+                aria-label="발행일"
+                dateTime={sospeso.issuedAt.toISOString()}
+                className="ml-auto text-[11px]"
+              >
                 {format년월일(sospeso.issuedAt)}
-              </span>
+              </time>
             </div>
             <div className="max-w-max">
-              <div className="mb-[2px] font-bold">
+              <h3 className="mb-[2px] font-bold" id={`to-${sospeso.to}`}>
                 <span className="mr-[13px]">TO.</span>
                 <span>{sospeso.to}</span>
-              </div>
+              </h3>
               <div className="h-[2px] w-full min-w-[220px] bg-black" />
             </div>
             <div className="absolute bottom-3 right-1">

--- a/src/components/SospesoCardList.tsx
+++ b/src/components/SospesoCardList.tsx
@@ -1,7 +1,6 @@
 import { format년월일 } from "@/adapters/dateApi";
 import { Link } from "@/routing/Link";
 import type { SospesoStatus } from "@/sospeso/domain";
-import { clsx } from "clsx";
 
 export function SospesoCardList({
   sospesoList,
@@ -15,27 +14,47 @@ export function SospesoCardList({
   }[];
 }) {
   return (
-    <div className="">
+    <div className="flex flex-col gap-3 ">
       {sospesoList.map((sospeso) => (
         <Link
-          className="btn btn-sm"
           routeKey="소스페소-상세"
           params={{ sospesoId: sospeso.id }}
           key={sospeso.id}
         >
-          <div className={clsx(sospeso.status === "pending" && "opacity-70")}>
-            <span>{sospeso.from}</span>
-            <span>{sospeso.to}</span>
-            <span>{format년월일(sospeso.issuedAt)}</span>
-            {sospeso.status === "pending" && (
-              <div className="flex items-center gap-1">신청자 있음</div>
-            )}
-            {sospeso.status === "consumed" && (
-              <div className="flex items-center gap-1">사용함</div>
-            )}
+          <div className="border border-black p-2.5 relative">
+            <div className="flex items-center mb-6">
+              <span className="mr-[9px] font-bold">FROM.</span>
+              <span>{sospeso.from}</span>
+              <span className="ml-auto text-[11px]">
+                {format년월일(sospeso.issuedAt)}
+              </span>
+            </div>
+            <div className="max-w-max">
+              <div className="mb-[2px] font-bold">
+                <span className="mr-[13px]">TO.</span>
+                <span>{sospeso.to}</span>
+              </div>
+              <div className="h-[2px] w-full min-w-[220px] bg-black" />
+            </div>
+            <div className="absolute bottom-3 right-1">
+              {sospeso.status === "pending" && (
+                <StatusStamp>신청자 있음</StatusStamp>
+              )}
+              {sospeso.status === "consumed" && (
+                <StatusStamp>사용함</StatusStamp>
+              )}
+            </div>
           </div>
         </Link>
       ))}
+    </div>
+  );
+}
+
+function StatusStamp({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="border-[3px] min-w-[78px] border-[#E51516] text-[#E51516] [transform:rotate(-18deg)] text-center">
+      <span className="text-[13px] leading-[15.51px]">{children}</span>
     </div>
   );
 }

--- a/src/components/SospesoCardList.tsx
+++ b/src/components/SospesoCardList.tsx
@@ -1,0 +1,41 @@
+import { format년월일 } from "@/adapters/dateApi";
+import { Link } from "@/routing/Link";
+import type { SospesoStatus } from "@/sospeso/domain";
+import { clsx } from "clsx";
+
+export function SospesoCardList({
+  sospesoList,
+}: {
+  sospesoList: {
+    id: string;
+    from: string;
+    to: string;
+    issuedAt: Date;
+    status: SospesoStatus;
+  }[];
+}) {
+  return (
+    <div className="">
+      {sospesoList.map((sospeso) => (
+        <Link
+          className="btn btn-sm"
+          routeKey="소스페소-상세"
+          params={{ sospesoId: sospeso.id }}
+          key={sospeso.id}
+        >
+          <div className={clsx(sospeso.status === "pending" && "opacity-70")}>
+            <span>{sospeso.from}</span>
+            <span>{sospeso.to}</span>
+            <span>{format년월일(sospeso.issuedAt)}</span>
+            {sospeso.status === "pending" && (
+              <div className="flex items-center gap-1">신청자 있음</div>
+            )}
+            {sospeso.status === "consumed" && (
+              <div className="flex items-center gap-1">사용함</div>
+            )}
+          </div>
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import { sospesoRepo } from "@/actions/actions.ts";
+import { SospesoCardList } from "@/components/SospesoCardList";
 import { SospesoFilter } from "@/components/SospesoFilter";
 import { SospesoList } from "@/components/SospesoList.tsx";
 import Layout from "@/layouts/Layout.astro";
@@ -7,6 +8,8 @@ import { Link } from "@/routing/Link.tsx";
 import { parseRouteParamsFromUrl } from "@/routing/parseRouteParams.ts";
 import { SospesoLogo } from "@/shared/icons/SospesoLogo";
 import { Pagination } from "@/shared/Pagination.tsx";
+import { calcStatus } from "@/sospeso/domain";
+import { pick, randomSospeso } from "@/sospeso/fixtures";
 
 const params = parseRouteParamsFromUrl("홈", new URL(Astro.url));
 const page = Math.max(params.page ?? 1, 1);
@@ -22,6 +25,18 @@ if (!sospesoList) {
     statusText: "Not found",
   });
 }
+
+const mockSospesoList = Array.from({ length: 10 }).map((_, _i) => {
+  const sospeso = randomSospeso(
+    pick(["issued", "consumed", "consumed", "pending"]),
+  );
+
+  return {
+    ...sospeso,
+    status: calcStatus(sospeso),
+    issuedAt: sospeso.issuing.issuedAt,
+  };
+});
 ---
 
 <Layout title="코칭 소스페소">
@@ -57,14 +72,22 @@ if (!sospesoList) {
     )
   }
 
-  <section class="mx-auto max-w-3xl flex flex-col items-center gap-4">
+  <section
+    class="mx-auto max-w-3xl flex-col items-center gap-4 mobile:flex hidden"
+  >
     <SospesoFilter currentStatus={params.status} />
-    <SospesoList sospesoList={sospesoList} />
+    <SospesoList sospesoList={mockSospesoList} />
     <Pagination
       routeKey="홈"
       params={{ status: params.status }}
       current={page}
       end={totalPage}
     />
+  </section>
+
+  <section
+    class="mx-auto max-w-3xl flex-col items-center gap-4 mobile:hidden flex"
+  >
+    <SospesoCardList sospesoList={mockSospesoList} />
   </section>
 </Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,8 +8,6 @@ import { Link } from "@/routing/Link.tsx";
 import { parseRouteParamsFromUrl } from "@/routing/parseRouteParams.ts";
 import { SospesoLogo } from "@/shared/icons/SospesoLogo";
 import { Pagination } from "@/shared/Pagination.tsx";
-import { calcStatus } from "@/sospeso/domain";
-import { pick, randomSospeso } from "@/sospeso/fixtures";
 
 const params = parseRouteParamsFromUrl("홈", new URL(Astro.url));
 const page = Math.max(params.page ?? 1, 1);
@@ -25,18 +23,6 @@ if (!sospesoList) {
     statusText: "Not found",
   });
 }
-
-const mockSospesoList = Array.from({ length: 10 }).map((_, _i) => {
-  const sospeso = randomSospeso(
-    pick(["issued", "consumed", "consumed", "pending"]),
-  );
-
-  return {
-    ...sospeso,
-    status: calcStatus(sospeso),
-    issuedAt: sospeso.issuing.issuedAt,
-  };
-});
 ---
 
 <Layout title="코칭 소스페소">
@@ -76,7 +62,7 @@ const mockSospesoList = Array.from({ length: 10 }).map((_, _i) => {
     class="mx-auto max-w-3xl flex-col items-center gap-4 mobile:flex hidden"
   >
     <SospesoFilter currentStatus={params.status} />
-    <SospesoList sospesoList={mockSospesoList} />
+    <SospesoList sospesoList={sospesoList} />
     <Pagination
       routeKey="홈"
       params={{ status: params.status }}
@@ -85,9 +71,7 @@ const mockSospesoList = Array.from({ length: 10 }).map((_, _i) => {
     />
   </section>
 
-  <section
-    class="mx-auto max-w-3xl flex-col items-center gap-4 mobile:hidden flex"
-  >
-    <SospesoCardList sospesoList={mockSospesoList} />
+  <section class="mx-auto max-w-3xl flex-col items-center gap-4 mobile:hidden">
+    <SospesoCardList sospesoList={sospesoList} />
   </section>
 </Layout>

--- a/src/stories/SospesoCardList.stories.tsx
+++ b/src/stories/SospesoCardList.stories.tsx
@@ -1,0 +1,39 @@
+import { SospesoCardList } from "@/components/SospesoCardList";
+import { calcStatus } from "@/sospeso/domain";
+import {
+  pick,
+  randomSospeso,
+  TEST_SOSPESO_LIST_ITEM,
+} from "@/sospeso/fixtures";
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof SospesoCardList> = {
+  component: SospesoCardList,
+};
+
+export default meta;
+type Story = StoryObj<typeof SospesoCardList>;
+
+export const Base: Story = {
+  args: {
+    sospesoList: [TEST_SOSPESO_LIST_ITEM],
+  },
+};
+
+const sospesoList = Array.from({ length: 10 }).map((_, _i) => {
+  const sospeso = randomSospeso(
+    pick(["issued", "consumed", "consumed", "pending"]),
+  );
+
+  return {
+    ...sospeso,
+    status: calcStatus(sospeso),
+    issuedAt: sospeso.issuing.issuedAt,
+  };
+});
+
+export const Ten: Story = {
+  args: {
+    sospesoList,
+  },
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,6 +8,11 @@ export default {
       aria: {
         "current-page": 'current="page"',
       },
+      screens: {
+        mobile: "576px",
+        laptop: "1024px",
+        desktop: "1280px",
+      },
     },
   },
   daisyui: {


### PR DESCRIPTION
기존 컴포넌트는 그대로 두고 카드 목록을 breakpoint에 따라 반환하도록 구현했는데 이유는 다음과 같습니다.
- 모바일 디자인은 테이블이 아닌 카드 목록 형식
- 페이지네이션인지, 무한 스크롤 형식인지 아직 확실하지 않음
- 필터 UI 적용도 확인 필요


구현 방식이나 현재 디자인에서는 파악하기 어려운 내용 등 고민되는 지점들이 있었어요. 페어할 때 여쭤보면서 진행하고 싶었는데 먼저 디자인 구현에 초점을 맞춰 작업했습니다. 여유있으실 때 의견 부탁드립니다 🙃


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced `SospesoCardList` component for displaying sospeso items.
	- Added mobile-responsive design for sospeso list view.

- **Tests**
	- Created comprehensive test suite for `SospesoCardList` component.
	- Added test cases for different sospeso statuses.

- **Improvements**
	- Enhanced Tailwind configuration with new responsive breakpoints.
	- Added Storybook documentation for `SospesoCardList`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->